### PR TITLE
feat: Remove broken annotation support, transparent containers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Add the plugin to your `.swcrc` configuration:
       "plugins": [
         ["swc-plugin-component-annotate", {
           "native": false,
-          "annotate-fragments": false,
           "ignored-components": ["MyIgnoredComponent"],
           "component-attr": "data-sentry-component",
           "element-attr": "data-sentry-element",
@@ -72,8 +71,6 @@ Add the plugin to your `.swcrc` configuration:
 - **`native`** (boolean, default: `false`): Use React Native attribute names (camelCase)
   - `false`: `data-component`, `data-element`, `data-source-file`
   - `true`: `dataComponent`, `dataElement`, `dataSourceFile`
-
-- **`annotate-fragments`** (boolean, default: `false`): Whether to annotate fragment children with component information
 
 - **`ignored-components`** (array, default: `[]`): List of component names to skip during annotation
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,9 +6,7 @@ pub struct PluginConfig {
     #[serde(default)]
     pub native: bool,
 
-    /// Whether to annotate fragment children with component information
-    #[serde(default, rename = "annotate-fragments")]
-    pub annotate_fragments: bool,
+
 
     /// List of component names to ignore during annotation
     #[serde(default, rename = "ignored-components")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,8 +6,6 @@ pub struct PluginConfig {
     #[serde(default)]
     pub native: bool,
 
-
-
     /// List of component names to ignore during annotation
     #[serde(default, rename = "ignored-components")]
     pub ignored_components: Vec<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ impl ReactComponentAnnotateVisitor {
     fn process_jsx_element(&mut self, element: &mut JSXElement) {
         // Check if this is a named fragment (Fragment, React.Fragment)
         let is_fragment = is_react_fragment(&element.opening.name);
-        
+
         if !is_fragment {
             self.add_attributes_to_element(&mut element.opening);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,26 +55,30 @@ impl ReactComponentAnnotateVisitor {
     }
 
     fn process_jsx_element(&mut self, element: &mut JSXElement) {
-        self.add_attributes_to_element(&mut element.opening);
+        // Check if this is a named fragment (Fragment, React.Fragment)
+        let is_fragment = is_react_fragment(&element.opening.name);
+        
+        if !is_fragment {
+            self.add_attributes_to_element(&mut element.opening);
+        }
 
-        // Process children
+        // Process children - fragments are transparent containers
         for child in &mut element.children {
             match child {
                 JSXElementChild::JSXElement(jsx_element) => {
-                    // Children don't get component name, only element name
-                    let prev_component = self.current_component_name.take();
-                    jsx_element.visit_mut_with(self);
-                    self.current_component_name = prev_component;
+                    if is_fragment {
+                        // Fragment children are processed without clearing component name
+                        jsx_element.visit_mut_with(self);
+                    } else {
+                        // Non-fragment children don't get component name, only element name
+                        let prev_component = self.current_component_name.take();
+                        jsx_element.visit_mut_with(self);
+                        self.current_component_name = prev_component;
+                    }
                 }
                 JSXElementChild::JSXFragment(jsx_fragment) => {
-                    let prev_component = if self.config.annotate_fragments {
-                        // Keep component name for first child of fragment
-                        self.current_component_name.clone()
-                    } else {
-                        self.current_component_name.take()
-                    };
+                    // Fragments are always transparent containers
                     jsx_fragment.visit_mut_with(self);
-                    self.current_component_name = prev_component;
                 }
                 _ => {}
             }
@@ -82,32 +86,14 @@ impl ReactComponentAnnotateVisitor {
     }
 
     fn process_jsx_fragment(&mut self, fragment: &mut JSXFragment) {
-        // Process children
-        let mut first_element_processed = false;
+        // Fragments are transparent containers - just process children
         for child in &mut fragment.children {
             match child {
                 JSXElementChild::JSXElement(jsx_element) => {
-                    if self.config.annotate_fragments && !first_element_processed {
-                        // First child of fragment gets component name
-                        first_element_processed = true;
-                        jsx_element.visit_mut_with(self);
-                    } else {
-                        // Other children don't get component name
-                        let prev_component = self.current_component_name.take();
-                        jsx_element.visit_mut_with(self);
-                        self.current_component_name = prev_component;
-                    }
+                    jsx_element.visit_mut_with(self);
                 }
                 JSXElementChild::JSXFragment(jsx_fragment) => {
-                    let prev_component =
-                        if self.config.annotate_fragments && !first_element_processed {
-                            first_element_processed = true;
-                            self.current_component_name.clone()
-                        } else {
-                            self.current_component_name.take()
-                        };
                     jsx_fragment.visit_mut_with(self);
-                    self.current_component_name = prev_component;
                 }
                 _ => {}
             }

--- a/tests/fixture/react_fragments/input.jsx
+++ b/tests/fixture/react_fragments/input.jsx
@@ -1,0 +1,83 @@
+import React, { Fragment } from 'react';
+
+const MyComponent = () => {
+  return (
+    <div>
+      <React.Fragment>
+        <h1>Using React.Fragment</h1>
+        <p>This is inside React.Fragment</p>
+      </React.Fragment>
+      
+      <Fragment>
+        <h2>Using Fragment</h2>
+        <span>This is inside Fragment</span>
+      </Fragment>
+      
+      <>
+        <h3>Using empty tag syntax</h3>
+        <button>This is inside empty tag fragment</button>
+      </>
+    </div>
+  );
+};
+
+const AnotherComponent = () => {
+  return (
+    <>
+      <p>Root fragment</p>
+      <div>Content inside root fragment</div>
+    </>
+  );
+};
+
+const EdgeCasesComponent = () => {
+  return (
+    <div>
+      {/* Nested fragments */}
+      <Fragment>
+        <Fragment>
+          <h1>Nested Fragment content</h1>
+        </Fragment>
+      </Fragment>
+      
+      {/* Mixed fragment types */}
+      <React.Fragment>
+        <>
+          <h2>Mixed fragment types</h2>
+        </>
+      </React.Fragment>
+      
+      {/* Conditional fragments */}
+      {true ? (
+        <Fragment>
+          <h3>Conditional fragment</h3>
+        </Fragment>
+      ) : (
+        <>
+          <h4>Alternative fragment</h4>
+        </>
+      )}
+      
+      {/* Fragment with single child */}
+      <Fragment>
+        <p>Single child in Fragment</p>
+      </Fragment>
+      
+      {/* Empty tag with single child */}
+      <>
+        <p>Single child in empty tag</p>
+      </>
+    </div>
+  );
+};
+
+const ConditionalComponent = () => {
+  return (
+    <>
+      {true && <div>Conditional content</div>}
+      {false || <span>Alternative content</span>}
+    </>
+  );
+};
+
+export default MyComponent; 

--- a/tests/fixture/react_fragments/output.jsx
+++ b/tests/fixture/react_fragments/output.jsx
@@ -1,0 +1,66 @@
+import React, { Fragment } from 'react';
+const MyComponent = ()=>{
+    return <div data-component="MyComponent" data-source-file="test.jsx">
+      <React.Fragment>
+        <h1>Using React.Fragment</h1>
+        <p>This is inside React.Fragment</p>
+      </React.Fragment>
+      
+      <Fragment>
+        <h2>Using Fragment</h2>
+        <span>This is inside Fragment</span>
+      </Fragment>
+      
+      <>
+        <h3 data-component="MyComponent" data-source-file="test.jsx">Using empty tag syntax</h3>
+        <button data-component="MyComponent" data-source-file="test.jsx">This is inside empty tag fragment</button>
+      </>
+    </div>;
+};
+const AnotherComponent = ()=>{
+    return <>
+      <p data-component="AnotherComponent" data-source-file="test.jsx">Root fragment</p>
+      <div data-component="AnotherComponent" data-source-file="test.jsx">Content inside root fragment</div>
+    </>;
+};
+const EdgeCasesComponent = ()=>{
+    return <div data-component="EdgeCasesComponent" data-source-file="test.jsx">
+      { /* Nested fragments */ }
+      <Fragment>
+        <Fragment>
+          <h1>Nested Fragment content</h1>
+        </Fragment>
+      </Fragment>
+      
+      { /* Mixed fragment types */ }
+      <React.Fragment>
+        <>
+          <h2>Mixed fragment types</h2>
+        </>
+      </React.Fragment>
+      
+      { /* Conditional fragments */ }
+      {true ? <Fragment>
+          <h3>Conditional fragment</h3>
+        </Fragment> : <>
+          <h4>Alternative fragment</h4>
+        </>}
+      
+      { /* Fragment with single child */ }
+      <Fragment>
+        <p>Single child in Fragment</p>
+      </Fragment>
+      
+      { /* Empty tag with single child */ }
+      <>
+        <p data-component="EdgeCasesComponent" data-source-file="test.jsx">Single child in empty tag</p>
+      </>
+    </div>;
+};
+const ConditionalComponent = ()=>{
+    return <>
+      {true && <div>Conditional content</div>}
+      {false || <span>Alternative content</span>}
+    </>;
+};
+export default MyComponent; 

--- a/tests/fixture/react_member_expressions/input.jsx
+++ b/tests/fixture/react_member_expressions/input.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Tab } from '@headlessui/react';
+import { Components } from 'my-ui-library';
+
+const MemberExpressionComponent = () => {
+  return (
+    <div>
+      {/* Simple member expressions */}
+      <Tab.Group>
+        <Tab.List>
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+        </Tab.List>
+        <Tab.Panels>
+          <Tab.Panel>Content 1</Tab.Panel>
+          <Tab.Panel>Content 2</Tab.Panel>
+        </Tab.Panels>
+      </Tab.Group>
+
+      {/* Nested member expressions */}
+      <Components.UI.Button>Click me</Components.UI.Button>
+      <Components.UI.Card>
+        <Components.UI.Card.Header>Title</Components.UI.Card.Header>
+        <Components.UI.Card.Body>Content</Components.UI.Card.Body>
+      </Components.UI.Card>
+
+      {/* React.Fragment member expression */}
+      <React.Fragment>
+        <h1>Inside React.Fragment</h1>
+        <p>This should not be annotated</p>
+      </React.Fragment>
+    </div>
+  );
+};
+
+export default MemberExpressionComponent; 

--- a/tests/fixture/react_member_expressions/output.jsx
+++ b/tests/fixture/react_member_expressions/output.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Tab } from '@headlessui/react';
+import { Components } from 'my-ui-library';
+const MemberExpressionComponent = ()=>{
+    return <div data-component="MemberExpressionComponent" data-source-file="test.jsx">
+      { /* Simple member expressions */ }
+      <Tab.Group data-element="Tab.Group" data-source-file="test.jsx">
+        <Tab.List data-element="Tab.List" data-source-file="test.jsx">
+          <Tab data-element="Tab" data-source-file="test.jsx">Tab 1</Tab>
+          <Tab data-element="Tab" data-source-file="test.jsx">Tab 2</Tab>
+        </Tab.List>
+        <Tab.Panels data-element="Tab.Panels" data-source-file="test.jsx">
+          <Tab.Panel data-element="Tab.Panel" data-source-file="test.jsx">Content 1</Tab.Panel>
+          <Tab.Panel data-element="Tab.Panel" data-source-file="test.jsx">Content 2</Tab.Panel>
+        </Tab.Panels>
+      </Tab.Group>
+
+      { /* Nested member expressions */ }
+      <Components.UI.Button data-element="Components.UI.Button" data-source-file="test.jsx">Click me</Components.UI.Button>
+      <Components.UI.Card data-element="Components.UI.Card" data-source-file="test.jsx">
+        <Components.UI.Card.Header data-element="Components.UI.Card.Header" data-source-file="test.jsx">Title</Components.UI.Card.Header>
+        <Components.UI.Card.Body data-element="Components.UI.Card.Body" data-source-file="test.jsx">Content</Components.UI.Card.Body>
+      </Components.UI.Card>
+
+      { /* React.Fragment member expression */ }
+      <React.Fragment>
+        <h1>Inside React.Fragment</h1>
+        <p>This should not be annotated</p>
+      </React.Fragment>
+    </div>;
+};
+export default MemberExpressionComponent; 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -86,7 +86,6 @@ fn test(input: PathBuf) {
     let is_ignored_components_test =
         dir.file_name().unwrap().to_str().unwrap() == "react_ignored_components";
 
-
     let config = if is_sentry_test || is_index_test {
         let mut config = PluginConfig::default();
         config.component_attr = Some("data-sentry-component".to_string());

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -86,6 +86,7 @@ fn test(input: PathBuf) {
     let is_ignored_components_test =
         dir.file_name().unwrap().to_str().unwrap() == "react_ignored_components";
 
+
     let config = if is_sentry_test || is_index_test {
         let mut config = PluginConfig::default();
         config.component_attr = Some("data-sentry-component".to_string());
@@ -172,7 +173,6 @@ fn test_plugin_config_parsing() {
     let config_json = r#"{
         "ignored-components": ["TestIgnored", "AnotherIgnored"],
         "native": true,
-        "annotate-fragments": true,
         "component-attr": "customComponent",
         "element-attr": "customElement",
         "source-file-attr": "customSourceFile"
@@ -189,7 +189,6 @@ fn test_plugin_config_parsing() {
         .ignored_components
         .contains(&"AnotherIgnored".to_string()));
     assert!(parsed_config.native);
-    assert!(parsed_config.annotate_fragments);
     assert_eq!(
         parsed_config.component_attr,
         Some("customComponent".to_string())


### PR DESCRIPTION
• **Removed broken `annotate-fragments` configuration** - fragments can't receive DOM attributes anyway
• **Fixed fragment handling** - now correctly acts as transparent containers matching React semantics  
• **Added comprehensive fragment tests** - covers `<Fragment>`, `<React.Fragment>`, `<>`, and edge cases
• **Added member expression tests** - supports `Tab.Group`, `Components.UI.Button`, etc.