### PR TITLE
feat: add rspack 1.7 plugin compatibility

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(target_arch = "wasm32")']
+rustflags = ["--cfg=swc_ast_unknown"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,17 +52,6 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "ast_node"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4902c7f39335a2390500ee791d6cb1778e742c7b97952497ec81449a5bfa3a7"
-dependencies = [
- "quote",
- "swc_macros_common",
- "syn",
-]
-
-[[package]]
-name = "ast_node"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb025ef00a6da925cf40870b9c8d008526b6004ece399cb0974209720f0b194"
@@ -233,6 +222,12 @@ checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "cbor4ii"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faed1a83001dc2c9201451030cc317e35bef36c84d3781d7c5bb9f343c397da8"
 
 [[package]]
 name = "cc"
@@ -437,16 +432,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "from_variant"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308530a56b099da144ebc5d8e179f343ad928fa2b3558d1eb3db9af18d6eff43"
-dependencies = [
- "swc_macros_common",
- "syn",
 ]
 
 [[package]]
@@ -1375,59 +1360,17 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "8.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40c2b43a19b5d0706aca8669ae5b77b92bd141f7f8ce5e980e0e52430f54b20"
-dependencies = [
- "bytecheck",
- "hstr",
- "once_cell",
- "rancor",
- "rkyv",
- "serde",
-]
-
-[[package]]
-name = "swc_atoms"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ccbe2ecad10ad7432100f878a107b1d972a8aee83ca53184d00c23a078bb8a"
 dependencies = [
+ "bytecheck",
+ "cbor4ii",
  "hstr",
  "once_cell",
- "serde",
-]
-
-[[package]]
-name = "swc_common"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e51fecd32bb0989543f0a64f4103cbd728e375838be83d768ce6989f5ea631"
-dependencies = [
- "anyhow",
- "ast_node 4.0.0",
- "better_scoped_tls",
- "bytecheck",
- "bytes-str",
- "either",
- "from_variant 2.0.2",
- "new_debug_unreachable",
- "num-bigint",
- "once_cell",
- "parking_lot",
  "rancor",
  "rkyv",
- "rustc-hash",
  "serde",
- "siphasher 0.3.11",
- "swc_atoms 8.0.2",
- "swc_eq_ignore_macros",
- "swc_sourcemap",
- "swc_visit",
- "termcolor",
- "tracing",
- "unicode-width 0.1.14",
- "url",
 ]
 
 [[package]]
@@ -1437,11 +1380,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77d9476c82da5448b227042b1e695fbe0456e7d749567e0d4ec7ac128f1e019d"
 dependencies = [
  "anyhow",
- "ast_node 5.0.0",
+ "ast_node",
  "better_scoped_tls",
  "bytes-str",
  "either",
- "from_variant 3.0.0",
+ "from_variant",
  "new_debug_unreachable",
  "num-bigint",
  "once_cell",
@@ -1449,7 +1392,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "siphasher 0.3.11",
- "swc_atoms 9.0.0",
+ "swc_atoms",
  "swc_eq_ignore_macros",
  "swc_visit",
  "termcolor",
@@ -1459,14 +1402,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_core"
-version = "46.0.3"
+name = "swc_common"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f062270a2c008b097af0f2f512fb7f6137c3ef26527fcfa7e1477acc7dc78bba"
+checksum = "a1c06698254e9b47daaf9bbb062af489a350bd8d10dfaab0cabbd32d46cec69d"
+dependencies = [
+ "anyhow",
+ "ast_node",
+ "better_scoped_tls",
+ "bytecheck",
+ "bytes-str",
+ "cbor4ii",
+ "either",
+ "from_variant",
+ "num-bigint",
+ "once_cell",
+ "parking_lot",
+ "rancor",
+ "rkyv",
+ "rustc-hash",
+ "serde",
+ "siphasher 0.3.11",
+ "swc_atoms",
+ "swc_eq_ignore_macros",
+ "swc_sourcemap",
+ "swc_visit",
+ "termcolor",
+ "tracing",
+ "unicode-width 0.2.1",
+ "url",
+]
+
+[[package]]
+name = "swc_core"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f361c932ffe029754a10512ee217f550109ee80dda1fe6ec90772440bfc0a68"
 dependencies = [
  "swc_allocator",
- "swc_atoms 8.0.2",
- "swc_common 16.0.0",
+ "swc_atoms",
+ "swc_common 18.0.1",
  "swc_ecma_ast",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
@@ -1481,31 +1456,29 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "17.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8bb0e5aaa6e077f178a28d29bc7da4a8ddaf012b3c21c043cb5f72a0b9779"
+checksum = "724195600825cbdd2a899d5473d2ce1f24ae418bff1231f160ecf38a3bc81f46"
 dependencies = [
  "bitflags",
- "bytecheck",
+ "cbor4ii",
  "is-macro",
  "num-bigint",
  "once_cell",
  "phf",
- "rancor",
- "rkyv",
  "rustc-hash",
  "string_enum",
- "swc_atoms 8.0.2",
- "swc_common 16.0.0",
+ "swc_atoms",
+ "swc_common 18.0.1",
  "swc_visit",
  "unicode-id-start",
 ]
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "19.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b756350060f51856d6d1f6ce63183b299d783d9d4458c1ecd6a3d72f4acf7e"
+checksum = "5c77d9d21345ca986ae3b5ff1a4fa3607b15b07ed397506e6dba32e867cf40fd"
 dependencies = [
  "ascii",
  "compact_str",
@@ -1517,8 +1490,8 @@ dependencies = [
  "ryu-js",
  "serde",
  "swc_allocator",
- "swc_atoms 8.0.2",
- "swc_common 16.0.0",
+ "swc_atoms",
+ "swc_common 18.0.1",
  "swc_ecma_ast",
  "swc_ecma_codegen_macros",
  "swc_sourcemap",
@@ -1538,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "26.0.1"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac3281dd9eef03b877fe9cef75a4c8951ce6df0c5f381868f302ee3c58fa6e2"
+checksum = "e1d0c36843109fff178bbedc439b4190daa865d78e553134243a4df220329fdd"
 dependencies = [
  "bitflags",
  "either",
@@ -1551,30 +1524,30 @@ dependencies = [
  "serde",
  "smartstring",
  "stacker",
- "swc_atoms 8.0.2",
- "swc_common 16.0.0",
+ "swc_atoms",
+ "swc_common 18.0.1",
  "swc_ecma_ast",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_testing"
-version = "17.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ba3446b9060debb0aa7f722b9bcdaf7865f88a91ab1e77f3b35f11f7935d3a"
+checksum = "177244625cdecd268a07534c3b087f7f263604dd40f3ec7c7a984ca95351b632"
 dependencies = [
  "anyhow",
  "hex",
  "sha2",
- "testing 17.0.0",
+ "testing 19.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "29.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e757ebf73dcab085bed9d1290bbe387c4cf889e21e105b4f480cbafac865ed9"
+checksum = "83f9f0dee4466e6eeb7042f2a0fc6c84298dfa914baff5bcfb44beb9f24b215f"
 dependencies = [
  "better_scoped_tls",
  "indexmap",
@@ -1583,8 +1556,8 @@ dependencies = [
  "phf",
  "rustc-hash",
  "serde",
- "swc_atoms 8.0.2",
- "swc_common 16.0.0",
+ "swc_atoms",
+ "swc_common 18.0.1",
  "swc_ecma_ast",
  "swc_ecma_parser",
  "swc_ecma_utils",
@@ -1594,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "32.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c95e674bc46c27db53aaa9b293fcfdb10b65a0fe02d33be1106ea6d0ad3b1e"
+checksum = "0df902ecb7e522c8df33f11db02fbed22abd4809663490100e3ea66c103130dd"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1605,7 +1578,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "swc_common 16.0.0",
+ "swc_common 18.0.1",
  "swc_ecma_ast",
  "swc_ecma_codegen",
  "swc_ecma_parser",
@@ -1615,14 +1588,14 @@ dependencies = [
  "swc_ecma_visit",
  "swc_sourcemap",
  "tempfile",
- "testing 17.0.0",
+ "testing 19.0.0",
 ]
 
 [[package]]
 name = "swc_ecma_utils"
-version = "23.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c17da9ae2d3ad51e865bb27aa97f68b89441ef0b6ee1ba507913c412303c9b7"
+checksum = "2dd5ee449d21110a271e73d0a9f7640a8854a62cb0e2cb0c9db3445383598e21"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -1630,8 +1603,8 @@ dependencies = [
  "par-core",
  "rustc-hash",
  "ryu-js",
- "swc_atoms 8.0.2",
- "swc_common 16.0.0",
+ "swc_atoms",
+ "swc_common 18.0.1",
  "swc_ecma_ast",
  "swc_ecma_visit",
  "tracing",
@@ -1639,14 +1612,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "17.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e6fea33cf8e654d46998cb65bf2915d3dbaab869a25f0ae2c70a86f1e7c2a4"
+checksum = "a69d63f7f704a2ec937edef90a3eba1f64602eceb60c8deb260c01131f680e8b"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
- "swc_atoms 8.0.2",
- "swc_common 16.0.0",
+ "swc_atoms",
+ "swc_common 18.0.1",
  "swc_ecma_ast",
  "swc_visit",
  "tracing",
@@ -1665,19 +1638,6 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8457a012c93109582b926c97716ff4408923bd54690a8b1fd6b138b1b6334cd"
-dependencies = [
- "anyhow",
- "miette",
- "once_cell",
- "serde",
- "swc_common 16.0.0",
-]
-
-[[package]]
-name = "swc_error_reporters"
 version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30c41e7b4f78298094092765ddf5b667491026a53a1d149c25b983188d471cbc"
@@ -1687,6 +1647,19 @@ dependencies = [
  "once_cell",
  "serde",
  "swc_common 17.0.0",
+]
+
+[[package]]
+name = "swc_error_reporters"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbc236f3f44337cbc13f49c7e25e92082e59279c268cbd928c3568f339d3fe0"
+dependencies = [
+ "anyhow",
+ "miette",
+ "once_cell",
+ "serde",
+ "swc_common 18.0.1",
 ]
 
 [[package]]
@@ -1722,16 +1695,14 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "17.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa8c82358eebd41d96ffe6f9e8d8ebb77218e1e44ec9bd5b9d986a060ae896e"
+checksum = "8f976dc63cd8b1916f265ee7d2647c28a85b433640099a5bf07153346dedffda"
 dependencies = [
  "better_scoped_tls",
- "bytecheck",
- "rancor",
- "rkyv",
+ "cbor4ii",
  "rustc-hash",
- "swc_common 16.0.0",
+ "swc_common 18.0.1",
  "swc_ecma_ast",
  "swc_trace_macro",
  "tracing",
@@ -1739,9 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "swc_sourcemap"
-version = "9.3.2"
+version = "9.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9755c673c6a83c461e98fa018f681adb8394a3f44f89a06f27e80fd4fe4fa1e4"
+checksum = "de08ef00f816acdd1a58ee8a81c0e1a59eefef2093aefe5611f256fa6b64c4d7"
 dependencies = [
  "base64-simd",
  "bitvec",
@@ -1768,14 +1739,14 @@ dependencies = [
 
 [[package]]
 name = "swc_transform_common"
-version = "10.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac052dc4f163680187023eaad6737cfeec2f7b69ac063bb004b3a4cc52407924"
+checksum = "6cc4a0e2aa9fac44d383127e01327710416dda5b637b0d134b7b8cf2ba6bde8e"
 dependencies = [
  "better_scoped_tls",
  "rustc-hash",
  "serde",
- "swc_common 16.0.0",
+ "swc_common 18.0.1",
 ]
 
 [[package]]
@@ -1840,27 +1811,6 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6071e9f3c50d975c85e606f2cc37c3a3ccff34cafc065f412fe7e04b94ae944"
-dependencies = [
- "cargo_metadata 0.18.1",
- "difference",
- "once_cell",
- "pretty_assertions",
- "regex",
- "rustc-hash",
- "serde",
- "serde_json",
- "swc_common 16.0.0",
- "swc_error_reporters 18.0.0",
- "testing_macros",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "testing"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e633123aa8ec1da20243f9eb885e55666f1182d451d6a5372d879f2f272aad"
@@ -1875,6 +1825,27 @@ dependencies = [
  "serde_json",
  "swc_common 17.0.0",
  "swc_error_reporters 19.0.0",
+ "testing_macros",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "testing"
+version = "19.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1506c602222ebab5d96100180f8d3c015b2394eceb00a46d20c25b8b1e5100"
+dependencies = [
+ "cargo_metadata 0.18.1",
+ "difference",
+ "once_cell",
+ "pretty_assertions",
+ "regex",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "swc_common 18.0.1",
+ "swc_error_reporters 20.0.0",
  "testing_macros",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ rustc-hash = "2.1.1"
 serde = { version = "1.0.225", features = ["derive"], default-features = false }
 serde_json = { version = "1.0.145", default-features = false }
 # Kept in line with rspack https://github.com/web-infra-dev/rspack/blob/main/Cargo.toml
-swc_core = { version = "46.0.2", features = ["ecma_plugin_transform"] }
+swc_core = { version = "54.0.0", features = ["ecma_plugin_transform"] }
 
 
 [dev-dependencies]
 testing = "18.0.0"
-swc_core = { version = "46.0.2", features = ["ecma_plugin_transform", "ecma_parser", "swc_ecma_transforms_testing"] }
+swc_core = { version = "54.0.0", features = ["ecma_plugin_transform", "ecma_parser", "swc_ecma_transforms_testing"] }
 
 [profile.release]
 codegen-units = 1
@@ -36,3 +36,6 @@ strip = "symbols"
 [profile.dev]
 incremental = true
 debug = 1
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(swc_ast_unknown)"] }

--- a/src/jsx_utils.rs
+++ b/src/jsx_utils.rs
@@ -15,7 +15,9 @@ pub fn is_react_fragment(element: &JSXElementName) -> bool {
             }
             false
         }
-        _ => false,
+        JSXElementName::JSXNamespacedName(_) => false,
+        #[cfg(swc_ast_unknown)]
+        _ => panic!("unknown jsx element name"),
     }
 }
 
@@ -30,6 +32,8 @@ pub fn get_element_name(element: &JSXElementName) -> Cow<str> {
         JSXElementName::JSXNamespacedName(namespaced) => {
             Cow::Owned(format!("{}:{}", namespaced.ns.sym, namespaced.name.sym))
         }
+        #[cfg(swc_ast_unknown)]
+        _ => panic!("unknown jsx element name"),
     }
 }
 
@@ -44,6 +48,8 @@ fn get_member_expression_name(member_expr: &JSXMemberExpr) -> String {
                 member_expr.prop.sym
             );
         }
+        #[cfg(swc_ast_unknown)]
+        _ => panic!("unknown jsx object"),
     };
 
     format!("{}.{}", obj_name, member_expr.prop.sym)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,8 @@ impl ReactComponentAnnotateVisitor {
                     // Fragments are always transparent containers
                     jsx_fragment.visit_mut_with(self);
                 }
+                #[cfg(swc_ast_unknown)]
+                JSXElementChild::Unknown(..) => panic!("unknown jsx element child"),
                 _ => {}
             }
         }
@@ -101,6 +103,8 @@ impl ReactComponentAnnotateVisitor {
                 JSXElementChild::JSXFragment(jsx_fragment) => {
                     jsx_fragment.visit_mut_with(self);
                 }
+                #[cfg(swc_ast_unknown)]
+                JSXElementChild::Unknown(..) => panic!("unknown jsx element child"),
                 _ => {}
             }
         }
@@ -210,6 +214,8 @@ impl ReactComponentAnnotateVisitor {
             Expr::Paren(paren_expr) => {
                 self.process_return_expression(&mut paren_expr.expr);
             }
+            #[cfg(swc_ast_unknown)]
+            Expr::Unknown(..) => panic!("unknown expr"),
             _ => {}
         }
     }
@@ -223,6 +229,8 @@ impl ReactComponentAnnotateVisitor {
         let callee_name = match call_expr.callee.as_expr() {
             Some(expr) => match expr.as_ref() {
                 Expr::Ident(ident) => ident.sym.as_ref(),
+                #[cfg(swc_ast_unknown)]
+                Expr::Unknown(..) => panic!("unknown expr"),
                 _ => return None,
             },
             _ => return None,
@@ -352,15 +360,22 @@ impl VisitMut for ReactComponentAnnotateVisitor {
                     ImportSpecifier::Named(named_import) => {
                         // Check if the imported name is 'default' or 'styled'
                         let imported_name = match &named_import.imported {
-                            Some(ModuleExportName::Ident(ident)) => ident.sym.as_ref(),
-                            None => named_import.local.sym.as_ref(),
-                            _ => continue,
+                            Some(ModuleExportName::Ident(ident)) => Some(ident.sym.as_ref()),
+                            Some(ModuleExportName::Str(str)) => str.value.as_str(),
+                            None => Some(named_import.local.sym.as_ref()),
+                            #[cfg(swc_ast_unknown)]
+                            Some(_) => panic!("unknown module export name"),
                         };
 
-                        if imported_name == "default" || imported_name == "styled" {
-                            self.styled_import = Some(named_import.local.sym.to_string());
+                        if let Some(imported_name) = imported_name {
+                            if imported_name == "default" || imported_name == "styled" {
+                                self.styled_import = Some(named_import.local.sym.to_string());
+                            }
                         }
                     }
+                    ImportSpecifier::Namespace(_) => {}
+                    #[cfg(swc_ast_unknown)]
+                    ImportSpecifier::Unknown(..) => panic!("unknown import specifier"),
                     _ => {}
                 }
             }
@@ -416,6 +431,11 @@ impl VisitMut for ReactComponentAnnotateVisitor {
                                 // Direct expression return
                                 self.process_return_expression(expr);
                             }
+                            #[cfg(swc_ast_unknown)]
+                            BlockStmtOrExpr::Unknown(..) => {
+                                panic!("unknown block stmt or expr")
+                            }
+                            _ => {}
                         }
 
                         self.current_component_name = None;
@@ -423,6 +443,8 @@ impl VisitMut for ReactComponentAnnotateVisitor {
                     Expr::Fn(func_expr) => {
                         self.find_jsx_in_function_body(&mut func_expr.function, component_name);
                     }
+                    #[cfg(swc_ast_unknown)]
+                    Expr::Unknown(..) => panic!("unknown expr"),
                     _ => {}
                 }
             }
@@ -436,25 +458,33 @@ impl VisitMut for ReactComponentAnnotateVisitor {
 
         // Look for render method
         for member in &mut class_decl.class.body {
-            if let ClassMember::Method(method) = member {
-                if let PropName::Ident(ident) = &method.key {
-                    if ident.sym.as_ref() == "render" {
-                        if let Some(body) = &mut method.function.body {
-                            self.current_component_name = Some(component_name.clone());
+            match member {
+                ClassMember::Method(method) => match &method.key {
+                    PropName::Ident(ident) => {
+                        if ident.sym.as_ref() == "render" {
+                            if let Some(body) = &mut method.function.body {
+                                self.current_component_name = Some(component_name.clone());
 
-                            // Look for return statements
-                            for stmt in &mut body.stmts {
-                                if let Stmt::Return(return_stmt) = stmt {
-                                    if let Some(arg) = &mut return_stmt.arg {
-                                        self.process_return_expression(arg);
+                                // Look for return statements
+                                for stmt in &mut body.stmts {
+                                    if let Stmt::Return(return_stmt) = stmt {
+                                        if let Some(arg) = &mut return_stmt.arg {
+                                            self.process_return_expression(arg);
+                                        }
                                     }
                                 }
-                            }
 
-                            self.current_component_name = None;
+                                self.current_component_name = None;
+                            }
                         }
                     }
-                }
+                    #[cfg(swc_ast_unknown)]
+                    PropName::Unknown(..) => panic!("unknown prop name"),
+                    _ => {}
+                },
+                #[cfg(swc_ast_unknown)]
+                ClassMember::Unknown(..) => panic!("unknown class member"),
+                _ => {}
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,8 +375,7 @@ impl VisitMut for ReactComponentAnnotateVisitor {
                     }
                     ImportSpecifier::Namespace(_) => {}
                     #[cfg(swc_ast_unknown)]
-                    ImportSpecifier::Unknown(..) => panic!("unknown import specifier"),
-                    _ => {}
+                    _ => panic!("unknown import specifier"),
                 }
             }
         }
@@ -432,10 +431,7 @@ impl VisitMut for ReactComponentAnnotateVisitor {
                                 self.process_return_expression(expr);
                             }
                             #[cfg(swc_ast_unknown)]
-                            BlockStmtOrExpr::Unknown(..) => {
-                                panic!("unknown block stmt or expr")
-                            }
-                            _ => {}
+                            _ => panic!("unknown block stmt or expr"),
                         }
 
                         self.current_component_name = None;


### PR DESCRIPTION
Update swc_core to v54 to align with Rspack 1.7 requirements, enable
swc_ast_unknown for wasm builds, and add Unknown enum handling to keep
plugin behavior stable across newer AST versions.

Refs:
- https://swc.rs/docs/plugin/ecmascript/compatibility#make-your-plugin-compatible
- https://rspack.rs/blog/announcing-1-7

