### PR TITLE
fix(react): Skip fragment-like provider annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_PROFILE_RELEASE_LTO: "fat"
@@ -16,11 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # https://github.com/actions/checkout
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      # https://github.com/wyvox/action-setup-pnpm
-      - uses: wyvox/action-setup-pnpm@v3
-        with: { node-version: 24 }
+      # https://github.com/pnpm/action-setup
+      - uses: pnpm/action-setup@v6
+
+      # https://github.com/actions/setup-node
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -28,7 +36,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Cache Cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dragonbox_ecma"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +501,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,9 +526,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hstr"
-version = "3.0.3"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c43c0a9e8fbdb3bb9dc8eee85e1e2ac81605418b4c83b6b7413cbf14d56ca5c"
+checksum = "83bb87e4b300d73412f6dcc7022ee7741452b51b155c2b06e5994d0770c2dbe2"
 dependencies = [
  "hashbrown 0.14.5",
  "new_debug_unreachable",
@@ -1097,13 +1109,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.11"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f5c3e5da784cd8c69d32cdc84673f3204536ca56e1fa01be31a74b92c932ac"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.15.4",
+ "hashbrown 0.17.1",
  "indexmap",
  "munge",
  "ptr_meta",
@@ -1116,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.11"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4270433626cffc9c4c1d3707dd681f2a2718d3d7b09ad754bec137acecda8d22"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1155,12 +1167,6 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "ryu-js"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
 name = "scoped-tls"
@@ -1343,7 +1349,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_core",
- "testing 18.0.0",
+ "testing",
 ]
 
 [[package]]
@@ -1360,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "9.0.0"
+version = "9.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ccbe2ecad10ad7432100f878a107b1d972a8aee83ca53184d00c23a078bb8a"
+checksum = "845f31910b5236db42dba106e8277681098d183b9b65b8dfa88ca8abe464aeff"
 dependencies = [
  "bytecheck",
  "cbor4ii",
@@ -1375,37 +1381,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "17.0.0"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d9476c82da5448b227042b1e695fbe0456e7d749567e0d4ec7ac128f1e019d"
-dependencies = [
- "anyhow",
- "ast_node",
- "better_scoped_tls",
- "bytes-str",
- "either",
- "from_variant",
- "new_debug_unreachable",
- "num-bigint",
- "once_cell",
- "parking_lot",
- "rustc-hash",
- "serde",
- "siphasher 0.3.11",
- "swc_atoms",
- "swc_eq_ignore_macros",
- "swc_visit",
- "termcolor",
- "tracing",
- "unicode-width 0.2.1",
- "url",
-]
-
-[[package]]
-name = "swc_common"
-version = "18.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c06698254e9b47daaf9bbb062af489a350bd8d10dfaab0cabbd32d46cec69d"
+checksum = "176fb11b1abd0a175e8ac47d4b061c5c8a9ae13b9196f30d44fe5db9cb7dfcbd"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -1435,13 +1413,13 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "54.0.0"
+version = "71.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f361c932ffe029754a10512ee217f550109ee80dda1fe6ec90772440bfc0a68"
+checksum = "aae246327702aef6fc2dbaf85a70c33301053cae287942185805c4b0411185fb"
 dependencies = [
  "swc_allocator",
  "swc_atoms",
- "swc_common 18.0.1",
+ "swc_common",
  "swc_ecma_ast",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
@@ -1456,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "19.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724195600825cbdd2a899d5473d2ce1f24ae418bff1231f160ecf38a3bc81f46"
+checksum = "a207e09f23885ff1f4354ebfdd4e715ccd4a68fca2e7e0df09baafbca850762e"
 dependencies = [
  "bitflags",
  "cbor4ii",
@@ -1469,32 +1447,31 @@ dependencies = [
  "rustc-hash",
  "string_enum",
  "swc_atoms",
- "swc_common 18.0.1",
+ "swc_common",
  "swc_visit",
  "unicode-id-start",
 ]
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "21.0.0"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c77d9d21345ca986ae3b5ff1a4fa3607b15b07ed397506e6dba32e867cf40fd"
+checksum = "a5a2fbf46c8cc66e112b6d8226ae0dacc6b983589df6192b38c7669d7721e02a"
 dependencies = [
  "ascii",
  "compact_str",
+ "dragonbox_ecma",
  "memchr",
  "num-bigint",
  "once_cell",
  "regex",
  "rustc-hash",
- "ryu-js",
  "serde",
  "swc_allocator",
  "swc_atoms",
- "swc_common 18.0.1",
+ "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen_macros",
- "swc_sourcemap",
  "tracing",
 ]
 
@@ -1511,9 +1488,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "32.0.0"
+version = "41.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d0c36843109fff178bbedc439b4190daa865d78e553134243a4df220329fdd"
+checksum = "f0f6c9c63026f4d1a70c3c6703446d42ce7b0fe83d4c33b6fe985faf96753f3e"
 dependencies = [
  "bitflags",
  "either",
@@ -1525,29 +1502,29 @@ dependencies = [
  "smartstring",
  "stacker",
  "swc_atoms",
- "swc_common 18.0.1",
+ "swc_common",
  "swc_ecma_ast",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_testing"
-version = "19.0.0"
+version = "24.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177244625cdecd268a07534c3b087f7f263604dd40f3ec7c7a984ca95351b632"
+checksum = "b91988c76b96fa85b2fc1d0831baf9d0ac5b2ddd8db43217322e5ca284e49908"
 dependencies = [
  "anyhow",
  "hex",
  "sha2",
- "testing 19.0.0",
+ "testing",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "35.0.0"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f9f0dee4466e6eeb7042f2a0fc6c84298dfa914baff5bcfb44beb9f24b215f"
+checksum = "f6b7a16c57147fed92672f74a76a71dd39d3dd8ae557126ba5028bd23f3a1930"
 dependencies = [
  "better_scoped_tls",
  "indexmap",
@@ -1557,7 +1534,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "swc_atoms",
- "swc_common 18.0.1",
+ "swc_common",
  "swc_ecma_ast",
  "swc_ecma_parser",
  "swc_ecma_utils",
@@ -1567,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "38.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df902ecb7e522c8df33f11db02fbed22abd4809663490100e3ea66c103130dd"
+checksum = "c379048fcf003e4afcefec58753f358992c622ab35b2fd075d7639cfc7c53e79"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1578,7 +1555,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "swc_common 18.0.1",
+ "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen",
  "swc_ecma_parser",
@@ -1588,23 +1565,23 @@ dependencies = [
  "swc_ecma_visit",
  "swc_sourcemap",
  "tempfile",
- "testing 19.0.0",
+ "testing",
 ]
 
 [[package]]
 name = "swc_ecma_utils"
-version = "25.0.0"
+version = "31.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd5ee449d21110a271e73d0a9f7640a8854a62cb0e2cb0c9db3445383598e21"
+checksum = "0d6dfe3d8deb3a2d399425996dddb2c421d268dbaf8132d2c1a859f6b9f7d8a2"
 dependencies = [
+ "dragonbox_ecma",
  "indexmap",
  "num_cpus",
  "once_cell",
  "par-core",
  "rustc-hash",
- "ryu-js",
  "swc_atoms",
- "swc_common 18.0.1",
+ "swc_common",
  "swc_ecma_ast",
  "swc_ecma_visit",
  "tracing",
@@ -1612,14 +1589,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "19.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69d63f7f704a2ec937edef90a3eba1f64602eceb60c8deb260c01131f680e8b"
+checksum = "1f9cb1e958e57fa6427c106674a12190c4578684beee783e3a0508f048d1b372"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
  "swc_atoms",
- "swc_common 18.0.1",
+ "swc_common",
  "swc_ecma_ast",
  "swc_visit",
  "tracing",
@@ -1638,28 +1615,15 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "19.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c41e7b4f78298094092765ddf5b667491026a53a1d149c25b983188d471cbc"
+checksum = "ac58facadaaf3cc9084503feaa5adb6299f12332a5f82045086fedc006f2b9ed"
 dependencies = [
  "anyhow",
  "miette",
  "once_cell",
  "serde",
- "swc_common 17.0.0",
-]
-
-[[package]]
-name = "swc_error_reporters"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbc236f3f44337cbc13f49c7e25e92082e59279c268cbd928c3568f339d3fe0"
-dependencies = [
- "anyhow",
- "miette",
- "once_cell",
- "serde",
- "swc_common 18.0.1",
+ "swc_common",
 ]
 
 [[package]]
@@ -1684,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_macro"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace467dfafbbdf3aecff786b8605b35db57d945e92fd88800569aa2cba0cdf61"
+checksum = "a5e9a8fbd3fa2fb4d2a16366d6bdd7c52484971d028c21e93cee20963e676530"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1695,24 +1659,23 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "19.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f976dc63cd8b1916f265ee7d2647c28a85b433640099a5bf07153346dedffda"
+checksum = "083ac69beff14ed7f44f5ca710c79d8eef82f62489c8b8e0f1f3aa27b88268f9"
 dependencies = [
  "better_scoped_tls",
  "cbor4ii",
  "rustc-hash",
- "swc_common 18.0.1",
+ "swc_common",
  "swc_ecma_ast",
- "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_sourcemap"
-version = "9.3.4"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de08ef00f816acdd1a58ee8a81c0e1a59eefef2093aefe5611f256fa6b64c4d7"
+checksum = "0c421e5e39e43a4b1b70c07922d7bffd5c22e8eff1340c0b15d0bfd0328822ee"
 dependencies = [
  "base64-simd",
  "bitvec",
@@ -1728,25 +1691,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_trace_macro"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfd2b4b0adb82e36f2ac688d00a6a67132c7f4170c772617516793a701be89e8"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "swc_transform_common"
-version = "12.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc4a0e2aa9fac44d383127e01327710416dda5b637b0d134b7b8cf2ba6bde8e"
+checksum = "1b4f1334cb6c6642de10080d9be47180f3536946968ee6f8ae8d0c2760111354"
 dependencies = [
  "better_scoped_tls",
  "rustc-hash",
  "serde",
- "swc_common 18.0.1",
+ "swc_common",
 ]
 
 [[package]]
@@ -1811,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "18.0.0"
+version = "24.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e633123aa8ec1da20243f9eb885e55666f1182d451d6a5372d879f2f272aad"
+checksum = "16937aa763ff6a4374024bbaa338c5867b687f3d1b84a79dbf71e0053a62b2eb"
 dependencies = [
  "cargo_metadata 0.18.1",
  "difference",
@@ -1823,29 +1776,8 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "swc_common 17.0.0",
- "swc_error_reporters 19.0.0",
- "testing_macros",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "testing"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1506c602222ebab5d96100180f8d3c015b2394eceb00a46d20c25b8b1e5100"
-dependencies = [
- "cargo_metadata 0.18.1",
- "difference",
- "once_cell",
- "pretty_assertions",
- "regex",
- "rustc-hash",
- "serde",
- "serde_json",
- "swc_common 18.0.1",
- "swc_error_reporters 20.0.0",
+ "swc_common",
+ "swc_error_reporters",
  "testing_macros",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ crate-type = ["cdylib", "lib"]
 rustc-hash = "2.1.1"
 serde = { version = "1.0.225", features = ["derive"], default-features = false }
 serde_json = { version = "1.0.145", default-features = false }
-# Kept in line with rspack https://github.com/web-infra-dev/rspack/blob/main/Cargo.toml
-swc_core = { version = "54.0.0", features = ["ecma_plugin_transform"] }
+# Pinned to the swc_core ABI embedded in @rspack/core 2.1.x.
+swc_core = { version = "=71.0.1", features = ["ecma_plugin_transform"] }
 
 
 [dev-dependencies]
-testing = "18.0.0"
-swc_core = { version = "54.0.0", features = ["ecma_plugin_transform", "ecma_parser", "swc_ecma_transforms_testing"] }
+testing = "24.0.1"
+swc_core = { version = "=71.0.1", features = ["ecma_plugin_transform", "ecma_parser", "swc_ecma_transforms_testing"] }
 
 [profile.release]
 codegen-units = 1

--- a/src/jsx_utils.rs
+++ b/src/jsx_utils.rs
@@ -1,22 +1,6 @@
 use std::borrow::Cow;
 use swc_core::ecma::ast::*;
 
-/// Check if a JSX element is a React Fragment
-#[inline]
-pub fn is_react_fragment(element: &JSXElementName) -> bool {
-    match element {
-        JSXElementName::Ident(ident) => ident.sym.as_ref() == "Fragment",
-        JSXElementName::JSXMemberExpr(member_expr) => matches!(
-            &member_expr.obj,
-            JSXObject::Ident(obj)
-                if obj.sym.as_ref() == "React" && member_expr.prop.sym.as_ref() == "Fragment"
-        ),
-        JSXElementName::JSXNamespacedName(_) => false,
-        #[cfg(swc_ast_unknown)]
-        _ => panic!("unknown jsx element name"),
-    }
-}
-
 /// Extract the element name from a JSX element
 #[inline]
 pub fn get_element_name(element: &JSXElementName) -> Cow<str> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,12 @@ pub mod path_utils;
 use config::PluginConfig;
 use jsx_utils::*;
 use path_utils::{extract_absolute_path, extract_filename};
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
     common::{FileName, DUMMY_SP},
     ecma::{
         ast::*,
+        atoms::Atom,
         visit::{noop_visit_mut_type, VisitMut, VisitMutWith},
     },
     plugin::{
@@ -19,6 +20,12 @@ use swc_core::{
     },
 };
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum JsxIdentifierStatus {
+    Annotatable,
+    Unannotatable,
+}
+
 pub struct ReactComponentAnnotateVisitor {
     config: PluginConfig,
     source_file_name: Option<Str>,
@@ -26,6 +33,10 @@ pub struct ReactComponentAnnotateVisitor {
     current_component_name: Option<String>,
     ignored_elements: &'static FxHashSet<&'static str>,
     ignored_components_set: FxHashSet<String>,
+    // JSX identifiers that may render React.Fragment cannot receive custom props.
+    jsx_identifier_scopes: Vec<FxHashMap<Atom, JsxIdentifierStatus>>,
+    fragment_component_identifiers: FxHashSet<Atom>,
+    react_namespace_identifiers: FxHashSet<Atom>,
     component_attr_ident: IdentName,
     element_attr_ident: IdentName,
     source_file_attr_ident: IdentName,
@@ -58,6 +69,10 @@ impl ReactComponentAnnotateVisitor {
             .source_path_attr
             .as_ref()
             .map(|_| IdentName::new(config.source_path_attr_name().into(), DUMMY_SP));
+        let mut fragment_component_identifiers = FxHashSet::default();
+        fragment_component_identifiers.insert("Fragment".into());
+        let mut react_namespace_identifiers = FxHashSet::default();
+        react_namespace_identifiers.insert("React".into());
 
         Self {
             component_attr_ident,
@@ -65,6 +80,9 @@ impl ReactComponentAnnotateVisitor {
             element_attr_ident,
             ignored_elements: constants::default_ignored_elements(),
             ignored_components_set,
+            jsx_identifier_scopes: Vec::new(),
+            fragment_component_identifiers,
+            react_namespace_identifiers,
             source_file_name,
             source_file_attr_ident,
             source_file_path,
@@ -84,9 +102,150 @@ impl ReactComponentAnnotateVisitor {
         self.ignored_elements.contains(element_name)
     }
 
+    #[inline]
+    fn is_unannotatable_identifier(&self, ident: &Atom) -> bool {
+        match self.scoped_jsx_identifier_status(ident) {
+            Some(JsxIdentifierStatus::Annotatable) => false,
+            Some(JsxIdentifierStatus::Unannotatable) => true,
+            None => self.fragment_component_identifiers.contains(ident),
+        }
+    }
+
+    #[inline]
+    fn scoped_jsx_identifier_status(&self, ident: &Atom) -> Option<JsxIdentifierStatus> {
+        self.jsx_identifier_scopes
+            .iter()
+            .rev()
+            .find_map(|scope| scope.get(ident).copied())
+    }
+
+    #[inline]
+    fn is_global_fragment_identifier(&self, ident: &Atom) -> bool {
+        self.scoped_jsx_identifier_status(ident).is_none()
+            && self.fragment_component_identifiers.contains(ident)
+    }
+
+    #[inline]
+    fn is_global_react_namespace_identifier(&self, ident: &Atom) -> bool {
+        self.scoped_jsx_identifier_status(ident).is_none()
+            && self.react_namespace_identifiers.contains(ident)
+    }
+
+    #[inline]
+    fn is_unannotatable_jsx_element_name(&self, element_name: &JSXElementName) -> bool {
+        let JSXElementName::Ident(ident) = element_name else {
+            return false;
+        };
+
+        self.is_unannotatable_identifier(&ident.sym)
+    }
+
+    #[inline]
+    fn is_react_fragment_element_name(&self, element_name: &JSXElementName) -> bool {
+        match element_name {
+            JSXElementName::Ident(ident) => self.is_global_fragment_identifier(&ident.sym),
+            JSXElementName::JSXMemberExpr(member_expr) => matches!(
+                &member_expr.obj,
+                JSXObject::Ident(obj)
+                    if self.is_global_react_namespace_identifier(&obj.sym)
+                        && member_expr.prop.sym.as_ref() == "Fragment"
+            ),
+            JSXElementName::JSXNamespacedName(_) => false,
+            #[cfg(swc_ast_unknown)]
+            _ => panic!("unknown jsx element name"),
+        }
+    }
+
+    fn expr_may_resolve_to_fragment(&self, expr: &Expr) -> bool {
+        match expr {
+            Expr::Ident(ident) => self.is_unannotatable_identifier(&ident.sym),
+            Expr::Member(member_expr) => {
+                let prop_is_fragment = matches!(
+                    &member_expr.prop,
+                    MemberProp::Ident(prop) if prop.sym.as_ref() == "Fragment"
+                );
+                prop_is_fragment
+                    && matches!(
+                        member_expr.obj.as_ref(),
+                        Expr::Ident(obj)
+                            if self.is_global_react_namespace_identifier(&obj.sym)
+                    )
+            }
+            Expr::Cond(cond_expr) => {
+                self.expr_may_resolve_to_fragment(&cond_expr.cons)
+                    || self.expr_may_resolve_to_fragment(&cond_expr.alt)
+            }
+            Expr::Paren(paren_expr) => self.expr_may_resolve_to_fragment(&paren_expr.expr),
+            Expr::Array(array_expr) => {
+                array_expr.elems.iter().flatten().any(|elem| {
+                    elem.spread.is_none() && self.expr_may_resolve_to_fragment(&elem.expr)
+                })
+            }
+            #[cfg(swc_ast_unknown)]
+            Expr::Unknown(..) => panic!("unknown expr"),
+            _ => false,
+        }
+    }
+
+    fn register_react_imports(&mut self, import_decl: &ImportDecl) {
+        if import_decl.src.value != "react" {
+            return;
+        }
+
+        for specifier in &import_decl.specifiers {
+            match specifier {
+                ImportSpecifier::Default(default_import) => {
+                    self.react_namespace_identifiers
+                        .insert(default_import.local.sym.clone());
+                }
+                ImportSpecifier::Namespace(namespace_import) => {
+                    self.react_namespace_identifiers
+                        .insert(namespace_import.local.sym.clone());
+                }
+                ImportSpecifier::Named(named_import) => {
+                    let imported_name = match &named_import.imported {
+                        Some(ModuleExportName::Ident(ident)) => Some(ident.sym.as_ref()),
+                        Some(ModuleExportName::Str(str)) => str.value.as_str(),
+                        None => Some(named_import.local.sym.as_ref()),
+                        #[cfg(swc_ast_unknown)]
+                        Some(_) => panic!("unknown module export name"),
+                    };
+
+                    if imported_name == Some("Fragment") {
+                        self.fragment_component_identifiers
+                            .insert(named_import.local.sym.clone());
+                    }
+                }
+                #[cfg(swc_ast_unknown)]
+                _ => panic!("unknown import specifier"),
+            }
+        }
+    }
+
+    fn register_jsx_identifier(&mut self, identifier: Atom, status: JsxIdentifierStatus) {
+        let should_insert = status == JsxIdentifierStatus::Unannotatable
+            || self.should_track_annotatable_identifier(&identifier);
+        if !should_insert {
+            return;
+        }
+
+        if let Some(scope) = self.jsx_identifier_scopes.last_mut() {
+            scope.insert(identifier, status);
+        } else if status == JsxIdentifierStatus::Unannotatable {
+            self.fragment_component_identifiers.insert(identifier);
+        }
+    }
+
+    #[inline]
+    fn should_track_annotatable_identifier(&self, identifier: &Atom) -> bool {
+        self.scoped_jsx_identifier_status(identifier).is_some()
+            || self.fragment_component_identifiers.contains(identifier)
+            || self.react_namespace_identifiers.contains(identifier)
+    }
+
     fn process_jsx_element(&mut self, element: &mut JSXElement) {
-        // Check if this is a named fragment (Fragment, React.Fragment)
-        let is_fragment = is_react_fragment(&element.opening.name);
+        // Check if this is a named fragment (Fragment, React.Fragment, or aliases)
+        let is_fragment = self.is_react_fragment_element_name(&element.opening.name);
 
         if !is_fragment {
             self.add_attributes_to_element(&mut element.opening);
@@ -135,6 +294,10 @@ impl ReactComponentAnnotateVisitor {
     }
 
     fn add_attributes_to_element(&self, opening_element: &mut JSXOpeningElement) {
+        if self.is_unannotatable_jsx_element_name(&opening_element.name) {
+            return;
+        }
+
         let element_name = get_element_name(&opening_element.name);
 
         // Check if component should be ignored
@@ -216,6 +379,14 @@ impl ReactComponentAnnotateVisitor {
     fn find_jsx_in_function_body(&mut self, func: &mut Function, component_name: String) {
         if let Some(body) = &mut func.body {
             self.current_component_name = Some(component_name);
+            self.jsx_identifier_scopes
+                .push(collect_function_param_scope(&func.params));
+
+            // Register aliases before processing returns so `<Provider />` can be skipped
+            // when `Provider` may resolve to Fragment.
+            for stmt in &body.stmts {
+                self.register_fragment_aliases_in_stmt(stmt);
+            }
 
             // Look for return statements
             for stmt in &mut body.stmts {
@@ -226,6 +397,7 @@ impl ReactComponentAnnotateVisitor {
                 }
             }
 
+            self.jsx_identifier_scopes.pop();
             self.current_component_name = None;
         }
     }
@@ -377,12 +549,114 @@ impl ReactComponentAnnotateVisitor {
             expr: Box::new(Expr::Arrow(arrow_func)),
         };
     }
+
+    fn register_fragment_aliases_in_stmt(&mut self, stmt: &Stmt) {
+        match stmt {
+            Stmt::Decl(Decl::Var(var_decl)) => {
+                self.register_fragment_aliases_in_var_decl(var_decl);
+            }
+            #[cfg(swc_ast_unknown)]
+            Stmt::Unknown(..) => panic!("unknown statement"),
+            _ => {}
+        }
+    }
+
+    fn register_fragment_aliases_in_var_decl(&mut self, var_decl: &VarDecl) {
+        for declarator in &var_decl.decls {
+            let Pat::Ident(ident) = &declarator.name else {
+                continue;
+            };
+
+            let Some(init) = &declarator.init else {
+                continue;
+            };
+
+            if self.expr_may_resolve_to_fragment(init) {
+                self.register_jsx_identifier(
+                    ident.id.sym.clone(),
+                    JsxIdentifierStatus::Unannotatable,
+                );
+            } else {
+                self.register_jsx_identifier(
+                    ident.id.sym.clone(),
+                    JsxIdentifierStatus::Annotatable,
+                );
+            }
+        }
+    }
+}
+
+fn collect_function_param_scope(params: &[Param]) -> FxHashMap<Atom, JsxIdentifierStatus> {
+    let mut scope = FxHashMap::default();
+
+    for param in params {
+        collect_pat_identifiers(&param.pat, &mut scope);
+    }
+
+    scope
+}
+
+fn collect_pat_list_scope(params: &[Pat]) -> FxHashMap<Atom, JsxIdentifierStatus> {
+    let mut scope = FxHashMap::default();
+
+    for param in params {
+        collect_pat_identifiers(param, &mut scope);
+    }
+
+    scope
+}
+
+fn collect_pat_identifiers(pat: &Pat, scope: &mut FxHashMap<Atom, JsxIdentifierStatus>) {
+    match pat {
+        Pat::Ident(binding_ident) => {
+            scope.insert(
+                binding_ident.id.sym.clone(),
+                JsxIdentifierStatus::Unannotatable,
+            );
+        }
+        Pat::Array(array_pat) => {
+            for elem in array_pat.elems.iter().flatten() {
+                collect_pat_identifiers(elem, scope);
+            }
+        }
+        Pat::Object(object_pat) => {
+            for prop in &object_pat.props {
+                match prop {
+                    ObjectPatProp::KeyValue(key_value) => {
+                        collect_pat_identifiers(&key_value.value, scope);
+                    }
+                    ObjectPatProp::Assign(assign) => {
+                        scope.insert(
+                            assign.key.id.sym.clone(),
+                            JsxIdentifierStatus::Unannotatable,
+                        );
+                    }
+                    ObjectPatProp::Rest(rest) => {
+                        collect_pat_identifiers(&rest.arg, scope);
+                    }
+                    #[cfg(swc_ast_unknown)]
+                    _ => panic!("unknown object pattern prop"),
+                }
+            }
+        }
+        Pat::Rest(rest_pat) => {
+            collect_pat_identifiers(&rest_pat.arg, scope);
+        }
+        Pat::Assign(assign_pat) => {
+            collect_pat_identifiers(&assign_pat.left, scope);
+        }
+        #[cfg(swc_ast_unknown)]
+        Pat::Unknown(..) => panic!("unknown pattern"),
+        _ => {}
+    }
 }
 
 impl VisitMut for ReactComponentAnnotateVisitor {
     noop_visit_mut_type!();
 
     fn visit_mut_import_decl(&mut self, import_decl: &mut ImportDecl) {
+        self.register_react_imports(import_decl);
+
         // Track imports from @emotion/styled (only if enabled)
         if self.config.experimental_rewrite_emotion_styled
             && import_decl.src.value == "@emotion/styled"
@@ -426,12 +700,31 @@ impl VisitMut for ReactComponentAnnotateVisitor {
         func_decl.visit_mut_children_with(self);
     }
 
+    fn visit_mut_function(&mut self, function: &mut Function) {
+        self.jsx_identifier_scopes
+            .push(collect_function_param_scope(&function.params));
+        function.visit_mut_children_with(self);
+        self.jsx_identifier_scopes.pop();
+    }
+
     fn visit_mut_var_declarator(&mut self, var_declarator: &mut VarDeclarator) {
         // Handle arrow functions and function expressions assigned to variables
         if let Pat::Ident(ident) = &var_declarator.name {
             let component_name = ident.id.sym.to_string();
 
             if let Some(init) = &mut var_declarator.init {
+                if self.expr_may_resolve_to_fragment(init) {
+                    self.register_jsx_identifier(
+                        ident.id.sym.clone(),
+                        JsxIdentifierStatus::Unannotatable,
+                    );
+                } else {
+                    self.register_jsx_identifier(
+                        ident.id.sym.clone(),
+                        JsxIdentifierStatus::Annotatable,
+                    );
+                }
+
                 match init.as_mut() {
                     Expr::Call(call_expr) => {
                         // Check if this is a styled(ComponentRef) pattern (only if enabled)
@@ -451,9 +744,15 @@ impl VisitMut for ReactComponentAnnotateVisitor {
                     }
                     Expr::Arrow(arrow_func) => {
                         self.current_component_name = Some(component_name);
+                        self.jsx_identifier_scopes
+                            .push(collect_pat_list_scope(&arrow_func.params));
 
                         match arrow_func.body.as_mut() {
                             BlockStmtOrExpr::BlockStmt(block) => {
+                                for stmt in &block.stmts {
+                                    self.register_fragment_aliases_in_stmt(stmt);
+                                }
+
                                 // Look for return statements in block
                                 for stmt in &mut block.stmts {
                                     if let Stmt::Return(return_stmt) = stmt {
@@ -471,6 +770,7 @@ impl VisitMut for ReactComponentAnnotateVisitor {
                             _ => panic!("unknown block stmt or expr"),
                         }
 
+                        self.jsx_identifier_scopes.pop();
                         self.current_component_name = None;
                     }
                     Expr::Fn(func_expr) => {
@@ -497,6 +797,12 @@ impl VisitMut for ReactComponentAnnotateVisitor {
                         if ident.sym.as_ref() == "render" {
                             if let Some(body) = &mut method.function.body {
                                 self.current_component_name = Some(component_name.clone());
+                                self.jsx_identifier_scopes
+                                    .push(collect_function_param_scope(&method.function.params));
+
+                                for stmt in &body.stmts {
+                                    self.register_fragment_aliases_in_stmt(stmt);
+                                }
 
                                 // Look for return statements
                                 for stmt in &mut body.stmts {
@@ -507,6 +813,7 @@ impl VisitMut for ReactComponentAnnotateVisitor {
                                     }
                                 }
 
+                                self.jsx_identifier_scopes.pop();
                                 self.current_component_name = None;
                             }
                         }
@@ -522,6 +829,19 @@ impl VisitMut for ReactComponentAnnotateVisitor {
         }
 
         class_decl.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_block_stmt(&mut self, block_stmt: &mut BlockStmt) {
+        self.jsx_identifier_scopes.push(FxHashMap::default());
+        block_stmt.visit_mut_children_with(self);
+        self.jsx_identifier_scopes.pop();
+    }
+
+    fn visit_mut_arrow_expr(&mut self, arrow_expr: &mut ArrowExpr) {
+        self.jsx_identifier_scopes
+            .push(collect_pat_list_scope(&arrow_expr.params));
+        arrow_expr.visit_mut_children_with(self);
+        self.jsx_identifier_scopes.pop();
     }
 
     fn visit_mut_jsx_element(&mut self, jsx_element: &mut JSXElement) {

--- a/tests/fixture/react_dynamic_component_fragment/input.jsx
+++ b/tests/fixture/react_dynamic_component_fragment/input.jsx
@@ -1,0 +1,117 @@
+import React, {Fragment, Fragment as ReactFragment} from 'react';
+import * as ReactNamespace from 'react';
+
+const Provider = ({children}) => <main>{children}</main>;
+
+const UserProvider = ({children}) => <section>{children}</section>;
+
+export function AppProviders({enabled, children}) {
+  const OrganizationProvider = enabled ? UserProvider : Fragment;
+  const providers = [OrganizationProvider, UserProvider];
+
+  return providers.reduceRight((acc, Provider) => <Provider>{acc}</Provider>, children);
+}
+
+export function DirectProvider({enabled, children}) {
+  const Provider = enabled ? UserProvider : Fragment;
+
+  return <Provider>{children}</Provider>;
+}
+
+export function AliasedImportProvider({enabled, children}) {
+  const Provider = enabled ? UserProvider : ReactFragment;
+
+  return <Provider>{children}</Provider>;
+}
+
+export function NamespaceProvider({enabled, children}) {
+  const Provider = enabled ? UserProvider : ReactNamespace.Fragment;
+
+  return <Provider>{children}</Provider>;
+}
+
+export function DefaultNamespaceProvider({enabled, children}) {
+  const Provider = enabled ? UserProvider : React.Fragment;
+
+  return <Provider>{children}</Provider>;
+}
+
+export function NamespaceFragmentChildren({children}) {
+  return <ReactNamespace.Fragment><span>{children}</span></ReactNamespace.Fragment>;
+}
+
+export function LocalAliasDoesNotLeak({children}) {
+  return <Provider>{children}</Provider>;
+}
+
+export function LocalProviderShadowsFragmentAlias({children}) {
+  const Provider = ({children}) => <article>{children}</article>;
+
+  return <Provider>{children}</Provider>;
+}
+
+export function LocalFragmentShadowsImport({children}) {
+  const Fragment = ({children}) => <article>{children}</article>;
+
+  return <Fragment>{children}</Fragment>;
+}
+
+export function LocalNamespaceShadowsImport({children}) {
+  const ReactNamespace = {
+    Fragment: ({children}) => <article>{children}</article>,
+  };
+
+  return <ReactNamespace.Fragment>{children}</ReactNamespace.Fragment>;
+}
+
+export function PropSlotProvider({Provider, children}) {
+  return <Provider>{children}</Provider>;
+}
+
+export function RenamedPropSlotProvider({provider: Provider, children}) {
+  return <Provider>{children}</Provider>;
+}
+
+export function BlockAliasDoesNotLeak({children}) {
+  if (children) {
+    const Provider = Fragment;
+    Provider;
+  }
+
+  return <Provider>{children}</Provider>;
+}
+
+export function BareBlockAliasDoesNotLeak({children}) {
+  {
+    const Provider = Fragment;
+    Provider;
+  }
+
+  return <Provider>{children}</Provider>;
+}
+
+export function BareBlockAliasAppliesInside({children}) {
+  {
+    const Provider = Fragment;
+    return <Provider>{children}</Provider>;
+  }
+}
+
+export function SwitchAliasDoesNotLeak({kind, children}) {
+  switch (kind) {
+    case 'fragment':
+      const Provider = Fragment;
+      Provider;
+      break;
+  }
+
+  return <Provider>{children}</Provider>;
+}
+
+export class ClassProviderAlias extends React.Component {
+  render() {
+    const Provider = Fragment;
+
+    return <Provider>{this.props.children}</Provider>;
+  }
+}

--- a/tests/fixture/react_dynamic_component_fragment/output.jsx
+++ b/tests/fixture/react_dynamic_component_fragment/output.jsx
@@ -1,0 +1,89 @@
+import React, { Fragment, Fragment as ReactFragment } from 'react';
+import * as ReactNamespace from 'react';
+const Provider = ({ children })=><main data-component="Provider" data-source-file="test.jsx">{children}</main>;
+const UserProvider = ({ children })=><section data-component="UserProvider" data-source-file="test.jsx">{children}</section>;
+export function AppProviders({ enabled, children }) {
+    const OrganizationProvider = enabled ? UserProvider : Fragment;
+    const providers = [
+        OrganizationProvider,
+        UserProvider
+    ];
+    return providers.reduceRight((acc, Provider)=><Provider>{acc}</Provider>, children);
+}
+export function DirectProvider({ enabled, children }) {
+    const Provider = enabled ? UserProvider : Fragment;
+    return <Provider>{children}</Provider>;
+}
+export function AliasedImportProvider({ enabled, children }) {
+    const Provider = enabled ? UserProvider : ReactFragment;
+    return <Provider>{children}</Provider>;
+}
+export function NamespaceProvider({ enabled, children }) {
+    const Provider = enabled ? UserProvider : ReactNamespace.Fragment;
+    return <Provider>{children}</Provider>;
+}
+export function DefaultNamespaceProvider({ enabled, children }) {
+    const Provider = enabled ? UserProvider : React.Fragment;
+    return <Provider>{children}</Provider>;
+}
+export function NamespaceFragmentChildren({ children }) {
+    return <ReactNamespace.Fragment><span data-component="NamespaceFragmentChildren" data-source-file="test.jsx">{children}</span></ReactNamespace.Fragment>;
+}
+export function LocalAliasDoesNotLeak({ children }) {
+    return <Provider data-element="Provider" data-component="LocalAliasDoesNotLeak" data-source-file="test.jsx">{children}</Provider>;
+}
+export function LocalProviderShadowsFragmentAlias({ children }) {
+    const Provider = ({ children })=><article data-component="Provider" data-source-file="test.jsx">{children}</article>;
+    return <Provider data-element="Provider" data-component="LocalProviderShadowsFragmentAlias" data-source-file="test.jsx">{children}</Provider>;
+}
+export function LocalFragmentShadowsImport({ children }) {
+    const Fragment = ({ children })=><article data-component="Fragment" data-source-file="test.jsx">{children}</article>;
+    return <Fragment data-element="Fragment" data-component="LocalFragmentShadowsImport" data-source-file="test.jsx">{children}</Fragment>;
+}
+export function LocalNamespaceShadowsImport({ children }) {
+    const ReactNamespace = {
+        Fragment: ({ children })=><article>{children}</article>
+    };
+    return <ReactNamespace.Fragment data-element="ReactNamespace.Fragment" data-component="LocalNamespaceShadowsImport" data-source-file="test.jsx">{children}</ReactNamespace.Fragment>;
+}
+export function PropSlotProvider({ Provider, children }) {
+    return <Provider>{children}</Provider>;
+}
+export function RenamedPropSlotProvider({ provider: Provider, children }) {
+    return <Provider>{children}</Provider>;
+}
+export function BlockAliasDoesNotLeak({ children }) {
+    if (children) {
+        const Provider = Fragment;
+        Provider;
+    }
+    return <Provider data-element="Provider" data-component="BlockAliasDoesNotLeak" data-source-file="test.jsx">{children}</Provider>;
+}
+export function BareBlockAliasDoesNotLeak({ children }) {
+    {
+        const Provider = Fragment;
+        Provider;
+    }
+    return <Provider data-element="Provider" data-component="BareBlockAliasDoesNotLeak" data-source-file="test.jsx">{children}</Provider>;
+}
+export function BareBlockAliasAppliesInside({ children }) {
+    {
+        const Provider = Fragment;
+        return <Provider>{children}</Provider>;
+    }
+}
+export function SwitchAliasDoesNotLeak({ kind, children }) {
+    switch(kind){
+        case 'fragment':
+            const Provider = Fragment;
+            Provider;
+            break;
+    }
+    return <Provider data-element="Provider" data-component="SwitchAliasDoesNotLeak" data-source-file="test.jsx">{children}</Provider>;
+}
+export class ClassProviderAlias extends React.Component {
+    render() {
+        const Provider = Fragment;
+        return <Provider>{this.props.children}</Provider>;
+    }
+}


### PR DESCRIPTION
Dynamic provider arrays can hand React.Fragment to JSX and we were adding data attrs to it, which React does not allow.

This tracks fragment imports/aliases and skips those unsafe providers while keeping shadowed local components annotatable. Also bumps the SWC ABI for Rspack 2.1 and refreshes the CI action versions while we're here.