### PR TITLE
feat(plugin): Add transparent components

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Add the plugin to your `.swcrc` configuration:
         ["swc-plugin-component-annotate", {
           "native": false,
           "ignored-components": ["MyIgnoredComponent"],
+          "transparent-components": ["Flex", "Stack"],
           "component-attr": "data-sentry-component",
           "element-attr": "data-sentry-element",
           "source-file-attr": "data-sentry-source-file"
@@ -71,6 +72,8 @@ Add the plugin to your `.swcrc` configuration:
   - `true`: `dataComponent`, `dataElement`, `dataSourceFile`
 
 - **`ignored-components`** (array, default: `[]`): List of component names to skip during annotation
+
+- **`transparent-components`** (array, default: `[]`): List of component names that should not add their own element annotations, but should still receive the current component annotation when rendered by another component. This is useful for layout primitives such as `Flex`, `Stack`, `Grid`, or `Container`.
 
 - **`component-attr`** (string, optional): Custom component attribute name (overrides default and native setting)
 
@@ -90,7 +93,8 @@ To use Sentry-specific attribute names for compatibility with Sentry's tracking:
         ["swc-plugin-component-annotate", {
           "component-attr": "data-sentry-component",
           "element-attr": "data-sentry-element",
-          "source-file-attr": "data-sentry-source-file"
+          "source-file-attr": "data-sentry-source-file",
+          "transparent-components": ["Container", "Flex", "Grid", "Stack"]
         }]
       ]
     }
@@ -105,6 +109,19 @@ This will generate attributes like:
     Click me
   </CustomButton>
 </div>
+```
+
+With `transparent-components`, layout primitives keep the owning component signal without adding noisy element names:
+
+```jsx
+function ReplayDetails() {
+  return <Flex />;
+}
+
+// Output
+function ReplayDetails() {
+  return <Flex data-sentry-component="ReplayDetails" data-sentry-source-file="ReplayDetails.jsx" />;
+}
 ```
 
 ## Examples

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,11 @@ pub struct PluginConfig {
     #[serde(default, rename = "ignored-components")]
     pub ignored_components: Vec<String>,
 
+    /// List of component names that should pass through the current component annotation
+    /// without adding their own element annotation
+    #[serde(default, rename = "transparent-components")]
+    pub transparent_components: Vec<String>,
+
     /// Custom component attribute name (overrides default and native setting)
     #[serde(default, rename = "component-attr")]
     pub component_attr: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,13 @@ enum JsxIdentifierStatus {
     Unannotatable,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ComponentAnnotationPolicy {
+    Normal,
+    Ignored,
+    Transparent,
+}
+
 pub struct ReactComponentAnnotateVisitor {
     config: PluginConfig,
     source_file_name: Option<Str>,
@@ -33,6 +40,7 @@ pub struct ReactComponentAnnotateVisitor {
     current_component_name: Option<String>,
     ignored_elements: &'static FxHashSet<&'static str>,
     ignored_components_set: FxHashSet<String>,
+    transparent_components_set: FxHashSet<String>,
     // JSX identifiers that may render React.Fragment cannot receive custom props.
     jsx_identifier_scopes: Vec<FxHashMap<Atom, JsxIdentifierStatus>>,
     fragment_component_identifiers: FxHashSet<Atom>,
@@ -61,6 +69,8 @@ impl ReactComponentAnnotateVisitor {
         // Pre-compute ignored components set for O(1) lookups
         let ignored_components_set: FxHashSet<String> =
             config.ignored_components.iter().cloned().collect();
+        let transparent_components_set: FxHashSet<String> =
+            config.transparent_components.iter().cloned().collect();
         let component_attr_ident = IdentName::new(config.component_attr_name().into(), DUMMY_SP);
         let element_attr_ident = IdentName::new(config.element_attr_name().into(), DUMMY_SP);
         let source_file_attr_ident =
@@ -80,6 +90,7 @@ impl ReactComponentAnnotateVisitor {
             element_attr_ident,
             ignored_elements: constants::default_ignored_elements(),
             ignored_components_set,
+            transparent_components_set,
             jsx_identifier_scopes: Vec::new(),
             fragment_component_identifiers,
             react_namespace_identifiers,
@@ -95,6 +106,32 @@ impl ReactComponentAnnotateVisitor {
     #[inline]
     pub fn should_ignore_component(&self, component_name: &str) -> bool {
         self.ignored_components_set.contains(component_name)
+    }
+
+    #[inline]
+    pub fn should_treat_component_as_transparent(&self, component_name: &str) -> bool {
+        self.transparent_components_set.contains(component_name)
+    }
+
+    #[inline]
+    fn component_annotation_policy(&self, component_name: &str) -> ComponentAnnotationPolicy {
+        if self.should_ignore_component(component_name) {
+            ComponentAnnotationPolicy::Ignored
+        } else if self.should_treat_component_as_transparent(component_name) {
+            ComponentAnnotationPolicy::Transparent
+        } else {
+            ComponentAnnotationPolicy::Normal
+        }
+    }
+
+    #[inline]
+    fn should_skip_component_return(&self, component_name: &str) -> bool {
+        self.component_annotation_policy(component_name) != ComponentAnnotationPolicy::Normal
+    }
+
+    #[inline]
+    fn should_skip_component_child_traversal(&self, component_name: &str) -> bool {
+        self.component_annotation_policy(component_name) == ComponentAnnotationPolicy::Transparent
     }
 
     #[inline]
@@ -302,7 +339,7 @@ impl ReactComponentAnnotateVisitor {
 
         // Check if component should be ignored
         if let Some(ref component_name) = self.current_component_name {
-            if self.should_ignore_component(component_name) {
+            if self.should_skip_component_return(component_name) {
                 return;
             }
         }
@@ -312,18 +349,21 @@ impl ReactComponentAnnotateVisitor {
         }
 
         let is_ignored_html = self.should_ignore_element(&element_name);
-        let add_element_attr = !is_ignored_html
+        let is_transparent_element = self.should_treat_component_as_transparent(&element_name);
+        let can_annotate_element = !is_ignored_html && !is_transparent_element;
+        let has_current_component = self.current_component_name.is_some();
+        let add_element_attr = can_annotate_element
             && !has_attribute(opening_element, self.config.element_attr_name())
             && (self.config.component_attr_name() != self.config.element_attr_name()
-                || self.current_component_name.is_none());
-        let add_component_attr = self.current_component_name.is_some()
+                || !has_current_component);
+        let add_component_attr = has_current_component
             && !has_attribute(opening_element, self.config.component_attr_name());
         let add_source_file_attr = self.source_file_name.is_some()
-            && (self.current_component_name.is_some() || !is_ignored_html)
+            && (has_current_component || can_annotate_element)
             && !has_attribute(opening_element, self.config.source_file_attr_name());
         let add_source_path_attr = self.source_file_path.is_some()
             && self.source_path_attr_ident.is_some()
-            && (self.current_component_name.is_some() || !is_ignored_html)
+            && (has_current_component || can_annotate_element)
             && !has_attribute(opening_element, self.config.source_path_attr_name());
 
         let attr_count = usize::from(add_element_attr)
@@ -696,8 +736,11 @@ impl VisitMut for ReactComponentAnnotateVisitor {
 
     fn visit_mut_fn_decl(&mut self, func_decl: &mut FnDecl) {
         let component_name = func_decl.ident.sym.to_string();
+        let should_skip_children = self.should_skip_component_child_traversal(&component_name);
         self.find_jsx_in_function_body(&mut func_decl.function, component_name);
-        func_decl.visit_mut_children_with(self);
+        if !should_skip_children {
+            func_decl.visit_mut_children_with(self);
+        }
     }
 
     fn visit_mut_function(&mut self, function: &mut Function) {
@@ -709,8 +752,12 @@ impl VisitMut for ReactComponentAnnotateVisitor {
 
     fn visit_mut_var_declarator(&mut self, var_declarator: &mut VarDeclarator) {
         // Handle arrow functions and function expressions assigned to variables
+        let mut should_skip_children = false;
+
         if let Pat::Ident(ident) = &var_declarator.name {
             let component_name = ident.id.sym.to_string();
+            let component_policy = self.component_annotation_policy(&component_name);
+            should_skip_children = component_policy == ComponentAnnotationPolicy::Transparent;
 
             if let Some(init) = &mut var_declarator.init {
                 if self.expr_may_resolve_to_fragment(init) {
@@ -728,7 +775,9 @@ impl VisitMut for ReactComponentAnnotateVisitor {
                 match init.as_mut() {
                     Expr::Call(call_expr) => {
                         // Check if this is a styled(ComponentRef) pattern (only if enabled)
-                        if self.config.experimental_rewrite_emotion_styled {
+                        if self.config.experimental_rewrite_emotion_styled
+                            && component_policy == ComponentAnnotationPolicy::Normal
+                        {
                             if let Some(ref_component_name) =
                                 self.is_styled_call_with_component_ref(call_expr)
                             {
@@ -783,11 +832,14 @@ impl VisitMut for ReactComponentAnnotateVisitor {
             }
         }
 
-        var_declarator.visit_mut_children_with(self);
+        if !should_skip_children {
+            var_declarator.visit_mut_children_with(self);
+        }
     }
 
     fn visit_mut_class_decl(&mut self, class_decl: &mut ClassDecl) {
         let component_name = class_decl.ident.sym.to_string();
+        let should_skip_children = self.should_skip_component_child_traversal(&component_name);
 
         // Look for render method
         for member in &mut class_decl.class.body {
@@ -828,7 +880,9 @@ impl VisitMut for ReactComponentAnnotateVisitor {
             }
         }
 
-        class_decl.visit_mut_children_with(self);
+        if !should_skip_children {
+            class_decl.visit_mut_children_with(self);
+        }
     }
 
     fn visit_mut_block_stmt(&mut self, block_stmt: &mut BlockStmt) {

--- a/tests/fixture/react_ignored_components/input.jsx
+++ b/tests/fixture/react_ignored_components/input.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 
 // This component should be ignored
 function IgnoredComponent() {
+  function NestedRegularComponent() {
+    return <aside>Nested regular component</aside>;
+  }
+
   return <div>This should not have attributes</div>;
 }
 
@@ -32,4 +36,4 @@ class RegularClassComponent extends React.Component {
   render() {
     return <article>Regular class component</article>;
   }
-} 
+}

--- a/tests/fixture/react_ignored_components/output.jsx
+++ b/tests/fixture/react_ignored_components/output.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 
 // This component should be ignored
 function IgnoredComponent() {
+    function NestedRegularComponent() {
+        return <aside data-component="NestedRegularComponent" data-source-file="test.jsx">Nested regular component</aside>;
+    }
   return <div>This should not have attributes</div>;
 }
 
@@ -32,4 +35,4 @@ class RegularClassComponent extends React.Component {
   render() {
     return <article data-component="RegularClassComponent" data-source-file="test.jsx">Regular class component</article>;
   }
-} 
+}

--- a/tests/fixture/react_transparent_components/input.jsx
+++ b/tests/fixture/react_transparent_components/input.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+function ReplayDetails() {
+  return <Flex />;
+}
+
+function MetricsToolbar() {
+  return <Grid />;
+}
+
+function CheckoutSummary() {
+  return (
+    <Stack>
+      <Button />
+      <StyledFlex />
+      <Grid />
+    </Stack>
+  );
+}
+
+function Flex(props) {
+  return <Container {...props} />;
+}
+
+function Stack(props) {
+  return <Flex {...props} />;
+}
+
+function Container({as: Component = 'div', ...rest}) {
+  return <Component {...rest} />;
+}
+
+const Grid = styled(Container);
+const StyledFlex = styled(Container);
+
+function Button() {
+  return <button>Click me</button>;
+}

--- a/tests/fixture/react_transparent_components/output.jsx
+++ b/tests/fixture/react_transparent_components/output.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import styled from '@emotion/styled';
+function ReplayDetails() {
+    return <Flex data-component="ReplayDetails" data-source-file="test.jsx"/>;
+}
+function MetricsToolbar() {
+    return <Grid data-component="MetricsToolbar" data-source-file="test.jsx"/>;
+}
+function CheckoutSummary() {
+    return <Stack data-component="CheckoutSummary" data-source-file="test.jsx">
+      <Button data-element="Button" data-source-file="test.jsx"/>
+      <StyledFlex data-element="StyledFlex" data-source-file="test.jsx"/>
+      <Grid/>
+    </Stack>;
+}
+function Flex(props) {
+    return <Container {...props}/>;
+}
+function Stack(props) {
+    return <Flex {...props}/>;
+}
+function Container({ as: Component = 'div', ...rest }) {
+    return <Component {...rest}/>;
+}
+const Grid = styled(Container);
+const StyledFlex = styled((props)=><Container data-element="StyledFlex" data-source-file="test.jsx" {...props}/>);
+function Button() {
+    return <button data-component="Button" data-source-file="test.jsx">Click me</button>;
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -117,6 +117,8 @@ fn test(input: PathBuf) {
     let is_source_path_test = dir.file_name().unwrap().to_str().unwrap() == "react_source_path";
     let is_inline_styled_test =
         dir.file_name().unwrap().to_str().unwrap() == "react_inline_styled_component";
+    let is_transparent_components_test =
+        dir.file_name().unwrap().to_str().unwrap() == "react_transparent_components";
 
     let config = if is_sentry_test || is_index_test {
         PluginConfig {
@@ -142,6 +144,17 @@ fn test(input: PathBuf) {
     } else if is_inline_styled_test {
         PluginConfig {
             experimental_rewrite_emotion_styled: true,
+            ..Default::default()
+        }
+    } else if is_transparent_components_test {
+        PluginConfig {
+            experimental_rewrite_emotion_styled: true,
+            transparent_components: vec![
+                "Container".to_string(),
+                "Flex".to_string(),
+                "Grid".to_string(),
+                "Stack".to_string(),
+            ],
             ..Default::default()
         }
     } else {
@@ -178,6 +191,7 @@ fn test_ignored_components_config() {
     // Test default config has no ignored components
     let default_config = PluginConfig::default();
     assert!(default_config.ignored_components.is_empty());
+    assert!(default_config.transparent_components.is_empty());
 
     // Test JSON parsing with ignored components
     let json_config = r#"{
@@ -221,6 +235,7 @@ fn test_plugin_config_parsing() {
     // Test that the plugin correctly parses JSON configuration with all options
     let config_json = r#"{
         "ignored-components": ["TestIgnored", "AnotherIgnored"],
+        "transparent-components": ["Container", "Flex"],
         "native": true,
         "component-attr": "customComponent",
         "element-attr": "customElement",
@@ -238,6 +253,13 @@ fn test_plugin_config_parsing() {
     assert!(parsed_config
         .ignored_components
         .contains(&"AnotherIgnored".to_string()));
+    assert_eq!(parsed_config.transparent_components.len(), 2);
+    assert!(parsed_config
+        .transparent_components
+        .contains(&"Container".to_string()));
+    assert!(parsed_config
+        .transparent_components
+        .contains(&"Flex".to_string()));
     assert!(parsed_config.native);
     assert_eq!(
         parsed_config.component_attr,


### PR DESCRIPTION
Adds a transparent component policy for layout primitives like Flex and Stack so they can keep the useful owner component/source attrs without adding noisy element names.

Also keeps ignored components on their old traversal path and covers the styled rewrite edge case so transparent styled primitives don't stamp their own annotations.

Example input:

```tsx
function ReplayDetails() {
  return <Flex direction="column" gap="md" />;
}

function Flex(props) {
  return <Container {...props} />;
}

function Container({as: Component = 'div', ...rest}) {
  return <Component {...rest} />;
}
```

Output with `Flex` and `Container` configured as transparent:

```tsx
function ReplayDetails() {
  return (
    <Flex
      direction="column"
      gap="md"
      data-component="ReplayDetails"
      data-source-file="replayDetails.tsx"
    />
  );
}

function Flex(props) {
  return <Container {...props} />;
}

function Container({as: Component = 'div', ...rest}) {
  return <Component {...rest} />;
}
```
