### PR TITLE
feat(plugin): Annotate JSX under the SWC React Compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "cargo build --release --target wasm32-unknown-unknown",
     "test": "cargo test",
     "typecheck": "tsc --noEmit",
-    "test:e2e": "node --test tests/e2e/swc-transform.test.ts",
+    "test:e2e": "node --test tests/e2e/*.test.ts",
     "prepack": "cp -rf target/wasm32-unknown-unknown/release/swc_plugin_component_annotate.wasm ."
   },
   "main": "swc_plugin_component_annotate.wasm",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,10 @@ pub struct ReactComponentAnnotateVisitor {
     current_component_name: Option<Atom>,
     fragment_child_component_name: Option<Atom>,
     current_return_component_name: Option<Atom>,
+    /// Owner for a render-root JSX element that the React Compiler hoisted out
+    /// of `return` into a memo-cache assignment (`t = <jsx>`), where
+    /// `visit_component_return_expr` no longer sees it.
+    render_root_owner: Option<Atom>,
     ignored_elements: &'static FxHashSet<&'static str>,
     ignored_components_set: FxHashSet<String>,
     transparent_components_set: FxHashSet<String>,
@@ -111,6 +115,7 @@ impl ReactComponentAnnotateVisitor {
             current_component_name: None,
             fragment_child_component_name: None,
             current_return_component_name: None,
+            render_root_owner: None,
             styled_import: None,
         }
     }
@@ -172,9 +177,11 @@ impl ReactComponentAnnotateVisitor {
         let can_annotate_element = !self.should_ignore_element(element_name)
             && element_policy == ComponentAnnotationPolicy::Normal;
         let owner_component_name = self.current_component_name.as_ref().or_else(|| {
-            (element_policy == ComponentAnnotationPolicy::Transparent)
-                .then_some(())
-                .and_then(|_| self.fragment_child_component_name.as_ref())
+            if element_policy == ComponentAnnotationPolicy::Transparent {
+                self.fragment_child_component_name.as_ref()
+            } else {
+                None
+            }
         });
         let has_owner_component = owner_component_name.is_some();
 
@@ -546,7 +553,33 @@ impl ReactComponentAnnotateVisitor {
         }
     }
 
+    /// Adopt a pending `render_root_owner` as the owner of this JSX root (see
+    /// the field docs). Taken for the duration so nested children aren't
+    /// mistaken for roots; pass the returned state to `restore_render_root`.
+    fn adopt_render_root(&mut self) -> (Option<Atom>, Option<Option<Atom>>) {
+        let root_owner = self.render_root_owner.take();
+        let restore_component = if self.current_component_name.is_none() {
+            root_owner
+                .as_ref()
+                .map(|owner| self.current_component_name.replace(owner.clone()))
+        } else {
+            None
+        };
+        (root_owner, restore_component)
+    }
+
+    fn restore_render_root(&mut self, state: (Option<Atom>, Option<Option<Atom>>)) {
+        let (root_owner, restore_component) = state;
+        if let Some(prev_component) = restore_component {
+            self.current_component_name = prev_component;
+        }
+        // Restore so sibling roots on the same render spine are still adopted.
+        self.render_root_owner = root_owner;
+    }
+
     fn process_jsx_element(&mut self, element: &mut JSXElement) {
+        let render_root = self.adopt_render_root();
+
         // Check if this is a named fragment (Fragment, React.Fragment, or aliases)
         let is_fragment = self.is_react_fragment_element_name(&element.opening.name);
 
@@ -559,10 +592,14 @@ impl ReactComponentAnnotateVisitor {
         } else {
             self.visit_element_jsx_children(element);
         }
+
+        self.restore_render_root(render_root);
     }
 
     fn process_jsx_fragment(&mut self, fragment: &mut JSXFragment) {
+        let render_root = self.adopt_render_root();
         self.visit_fragment_jsx_children(fragment);
+        self.restore_render_root(render_root);
     }
 
     fn visit_fragment_jsx_children<N>(&mut self, node: &mut N)
@@ -638,6 +675,8 @@ impl ReactComponentAnnotateVisitor {
         let prev_return_component = self.current_return_component_name.replace(component_name);
         let prev_component = self.current_component_name.take();
         let prev_fragment_child_component = self.fragment_child_component_name.take();
+        let prev_render_root = self.render_root_owner.clone();
+        self.render_root_owner = self.current_return_component_name.clone();
 
         self.jsx_bindings
             .push_function_with(collect_function_param_scope(&func.params));
@@ -647,6 +686,7 @@ impl ReactComponentAnnotateVisitor {
         self.current_return_component_name = prev_return_component;
         self.current_component_name = prev_component;
         self.fragment_child_component_name = prev_fragment_child_component;
+        self.render_root_owner = prev_render_root;
     }
 
     fn visit_arrow_as_component(&mut self, arrow_expr: &mut ArrowExpr, component_name: Atom) {
@@ -657,6 +697,8 @@ impl ReactComponentAnnotateVisitor {
         let prev_return_component = self.current_return_component_name.replace(component_name);
         let prev_component = self.current_component_name.take();
         let prev_fragment_child_component = self.fragment_child_component_name.take();
+        let prev_render_root = self.render_root_owner.clone();
+        self.render_root_owner = self.current_return_component_name.clone();
 
         self.jsx_bindings
             .push_function_with(collect_pat_list_scope(&arrow_expr.params));
@@ -675,6 +717,7 @@ impl ReactComponentAnnotateVisitor {
         self.current_return_component_name = prev_return_component;
         self.current_component_name = prev_component;
         self.fragment_child_component_name = prev_fragment_child_component;
+        self.render_root_owner = prev_render_root;
     }
 
     fn visit_component_return_expr(&mut self, expr: &mut Expr) {
@@ -760,13 +803,21 @@ impl VisitMut for ReactComponentAnnotateVisitor {
         let component_name = func_decl.ident.sym.clone();
         self.jsx_bindings
             .insert(func_decl.ident.to_id(), JsxIdentifierStatus::Annotatable);
-        self.visit_function_as_component(&mut func_decl.function, component_name);
+
+        // React Compiler helpers (`_temp`, `_temp2`, ...) are extracted inline
+        // callbacks, not components; traverse without attributing their JSX.
+        if is_react_compiler_temp(component_name.as_ref()) {
+            self.visit_mut_function(&mut func_decl.function);
+        } else {
+            self.visit_function_as_component(&mut func_decl.function, component_name);
+        }
     }
 
     fn visit_mut_function(&mut self, function: &mut Function) {
         let prev_return_component = self.current_return_component_name.take();
         let prev_component = self.current_component_name.take();
         let prev_fragment_child_component = self.fragment_child_component_name.take();
+        let prev_render_root = self.render_root_owner.take();
 
         self.jsx_bindings
             .push_function_with(collect_function_param_scope(&function.params));
@@ -776,6 +827,7 @@ impl VisitMut for ReactComponentAnnotateVisitor {
         self.current_return_component_name = prev_return_component;
         self.current_component_name = prev_component;
         self.fragment_child_component_name = prev_fragment_child_component;
+        self.render_root_owner = prev_render_root;
     }
 
     fn visit_mut_var_decl(&mut self, var_decl: &mut VarDecl) {
@@ -849,6 +901,7 @@ impl VisitMut for ReactComponentAnnotateVisitor {
         let prev_return_component = self.current_return_component_name.take();
         let prev_component = self.current_component_name.take();
         let prev_fragment_child_component = self.fragment_child_component_name.take();
+        let prev_render_root = self.render_root_owner.take();
 
         self.jsx_bindings
             .push_function_with(collect_pat_list_scope(&arrow_expr.params));
@@ -858,6 +911,7 @@ impl VisitMut for ReactComponentAnnotateVisitor {
         self.current_return_component_name = prev_return_component;
         self.current_component_name = prev_component;
         self.fragment_child_component_name = prev_fragment_child_component;
+        self.render_root_owner = prev_render_root;
     }
 
     fn visit_mut_return_stmt(&mut self, return_stmt: &mut ReturnStmt) {
@@ -873,6 +927,14 @@ impl VisitMut for ReactComponentAnnotateVisitor {
     fn visit_mut_jsx_fragment(&mut self, jsx_fragment: &mut JSXFragment) {
         self.process_jsx_fragment(jsx_fragment);
     }
+}
+
+/// Matches the module-scope helper names the React Compiler generates when it
+/// extracts inline callbacks / render closures (`_temp`, `_temp2`, ...).
+#[inline]
+fn is_react_compiler_temp(name: &str) -> bool {
+    name.strip_prefix("_temp")
+        .is_some_and(|rest| rest.bytes().all(|byte| byte.is_ascii_digit()))
 }
 
 // Export for testing

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,0 +1,41 @@
+import path from "node:path";
+import {transformSync, type Options} from "@swc/core";
+
+export type PluginConfig = Record<string, unknown>;
+
+const pluginPath = path.resolve(
+  "target/wasm32-unknown-unknown/release/swc_plugin_component_annotate.wasm"
+);
+
+/** Run source through @swc/core with the plugin wired in. */
+export function transform(
+  source: string,
+  pluginConfig: PluginConfig = {},
+  swcOptions: Pick<Options, "jsc"> = {}
+): string {
+  const jsc: NonNullable<Options["jsc"]> = {
+    parser: {syntax: "ecmascript", jsx: true},
+    experimental: {plugins: [[pluginPath, pluginConfig]]},
+  };
+
+  if (swcOptions.jsc?.transform) {
+    jsc.transform = swcOptions.jsc.transform;
+  }
+
+  return transformSync(source, {
+    filename: path.resolve("tests/e2e/Button.jsx"),
+    jsc,
+  }).code;
+}
+
+/** SWC options that enable the automatic runtime + React Compiler. */
+export const reactCompiler: Pick<Options, "jsc"> = {
+  jsc: {transform: {react: {runtime: "automatic"}, reactCompiler: true}},
+};
+
+/** Attribute names used by the Sentry-style config across tests. */
+export const sentryConfig: PluginConfig = {
+  "component-attr": "data-sentry-component",
+  "element-attr": "data-sentry-element",
+  "source-file-attr": "data-sentry-source-file",
+};

--- a/tests/e2e/react-compiler.test.ts
+++ b/tests/e2e/react-compiler.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import {test} from "node:test";
+
+import {reactCompiler, sentryConfig, transform} from "./helpers.ts";
+
+// The React Compiler runs before this plugin and hoists returned JSX out of
+// `return` into memo-cache assignments (`t = <jsx>`). These tests cover that
+// the owner still reaches those hoisted roots.
+
+test("passes owner metadata through transparent component callsites with React Compiler enabled", () => {
+  const code = transform(
+    `
+      function MergedItem() {
+        return (
+          <Grid>
+            <Button aria-label="Show fingerprints" />
+          </Grid>
+        );
+      }
+
+      function Grid(props) {
+        return <div {...props} />;
+      }
+
+      function Button(props) {
+        return <button {...props} />;
+      }
+    `,
+    {...sentryConfig, "transparent-components": ["Button", "Grid"]},
+    reactCompiler
+  );
+
+  assert.match(code, /_jsx\(Button, \{\s+"aria-label": "Show fingerprints",\s+"data-sentry-component": "MergedItem"/);
+  assert.doesNotMatch(code, /"data-sentry-element": "Button"/);
+  assert.match(code, /_jsx\("button", _object_spread\(\{\}, props\)\)/);
+});
+
+test("annotates cached React Compiler return values", () => {
+  const code = transform(
+    `
+      function Button() {
+        return <button />;
+      }
+    `,
+    {},
+    reactCompiler
+  );
+
+  assert.match(code, /_jsx\("button", \{\s+"data-component": "Button"/);
+});
+
+test("annotates nested cached React Compiler return values", () => {
+  const code = transform(
+    `
+      function ConditionalActions({enabled}) {
+        if (enabled) {
+          return <Button />;
+        }
+
+        return <div />;
+      }
+
+      function Button(props) {
+        return <button {...props} />;
+      }
+    `,
+    {...sentryConfig, "transparent-components": ["Button"]},
+    reactCompiler
+  );
+
+  assert.match(code, /_jsx\(Button, \{\s+"data-sentry-component": "ConditionalActions"/);
+  assert.match(code, /_jsx\("div", \{\s+"data-sentry-component": "ConditionalActions"/);
+  assert.doesNotMatch(code, /"data-sentry-element": "Button"/);
+});
+
+test("does not attribute React Compiler temp helpers as component owners", () => {
+  const code = transform(
+    `
+      function List({items}) {
+        return <ul>{items.map((i) => <li>{i}</li>)}</ul>;
+      }
+    `,
+    sentryConfig,
+    reactCompiler
+  );
+
+  assert.match(code, /"data-sentry-component": "List"/);
+  assert.doesNotMatch(code, /"data-sentry-component": "_temp"/);
+});
+
+test("still annotates elements inside React Compiler temp helpers without an owner", () => {
+  const code = transform(
+    `
+      function List({items}) {
+        return <ul>{items.map((i) => <Row />)}</ul>;
+      }
+    `,
+    sentryConfig,
+    reactCompiler
+  );
+
+  assert.doesNotMatch(code, /"data-sentry-component": "_temp"/);
+  assert.match(code, /_jsx\(Row, \{\s+"data-sentry-element": "Row"/);
+});
+
+// Rename-proof guard for the `is_react_compiler_temp` heuristic: instead of
+// matching the literal `_temp` name, assert the real invariant — only
+// source-defined components may become owners. A leak under any generated name
+// fails here, and the failure lists the offending name.
+test("only source-defined components become owners (guards against compiler helper renames)", () => {
+  const code = transform(
+    `
+      function List({items}) {
+        return (
+          <ul onClick={() => <b />}>
+            {items.map((i) => <li>{i}</li>)}
+          </ul>
+        );
+      }
+    `,
+    sentryConfig,
+    reactCompiler
+  );
+
+  const owners = new Set(
+    [...code.matchAll(/"data-sentry-component": "([^"]+)"/g)].map((match) => match[1])
+  );
+  assert.deepEqual([...owners], ["List"]);
+});

--- a/tests/e2e/swc-transform.test.ts
+++ b/tests/e2e/swc-transform.test.ts
@@ -1,30 +1,7 @@
 import assert from "node:assert/strict";
-import path from "node:path";
 import {test} from "node:test";
-import {transformSync, type Options} from "@swc/core";
 
-type PluginConfig = Record<string, unknown>;
-
-const pluginPath = path.resolve(
-  "target/wasm32-unknown-unknown/release/swc_plugin_component_annotate.wasm"
-);
-
-function transform(source: string, pluginConfig: PluginConfig = {}): string {
-  const options: Options = {
-    filename: path.resolve("tests/e2e/Button.jsx"),
-    jsc: {
-      parser: {
-        syntax: "ecmascript",
-        jsx: true,
-      },
-      experimental: {
-        plugins: [[pluginPath, pluginConfig]],
-      },
-    },
-  };
-
-  return transformSync(source, options).code;
-}
+import {sentryConfig, transform} from "./helpers.ts";
 
 test("annotates React components through @swc/core", () => {
   const code = transform(`
@@ -45,11 +22,7 @@ test("passes plugin config through the SWC wasm boundary", () => {
         return <Icon />;
       }
     `,
-    {
-      "component-attr": "data-sentry-component",
-      "element-attr": "data-sentry-element",
-      "source-file-attr": "data-sentry-source-file",
-    }
+    sentryConfig
   );
 
   assert.match(code, /"data-sentry-component": "Button"/);
@@ -88,12 +61,7 @@ test("passes owner metadata through transparent component callsites", () => {
         return <button {...props} />;
       }
     `,
-    {
-      "component-attr": "data-sentry-component",
-      "element-attr": "data-sentry-element",
-      "source-file-attr": "data-sentry-source-file",
-      "transparent-components": ["Button", "Flex", "Grid"],
-    }
+    {...sentryConfig, "transparent-components": ["Button", "Flex", "Grid"]}
   );
 
   assert.match(code, /React\.createElement\(Button, \{\s+"aria-label": "Show fingerprints",\s+"data-sentry-component": "MergedItem"/);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2024",
     "module": "preserve",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "types": ["node"],
     "strict": true,
     "noEmit": true,


### PR DESCRIPTION
When the SWC React Compiler is enabled it runs before this plugin and hoists a component's returned JSX out of `return` into a memo-cache assignment (`t = <jsx>`). Our owner tracking keyed off the `return`, so hoisted roots lost their `data-*-component` attribute and elements came out unannotated.

Fix tracks a render-root owner across the component body and adopts it for those hoisted roots, so annotation works the same with the compiler on or off. Also skips the compiler's extracted callback helpers (`_temp`, `_temp2`, ...) so their generated names don't leak in as component owners - matching how inline callbacks behave uncompiled.

There's a rename-proof guard test for that heuristic: instead of matching the literal `_temp` name, it asserts that only source-defined components ever become owners, so a leak under any future generated name fails loudly (and the failure prints the offending name).

While in here, split the e2e tests into `swc-transform` (base) and `react-compiler` files sharing a small harness, and fixed a pre-existing clippy lint that was already failing `clippy -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)