### PR TITLE
fix(plugin): Label transparent components with root owners

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Add the plugin to your `.swcrc` configuration:
 
 - **`ignored-components`** (array, default: `[]`): List of component names to skip during annotation
 
-- **`transparent-components`** (array, default: `[]`): List of pass-through component names that should keep the nearest owning component annotation instead of being reported as their own element. This is useful for layout primitives such as `Flex`, `Stack`, `Grid`, or `Container`, and for design-system primitives when owner-only DOM annotations are preferred.
+- **`transparent-components`** (array, default: `[]`): List of pass-through component names that should receive an `Owner-Component` annotation instead of being reported as their own element. This is useful for layout primitives such as `Flex`, `Stack`, `Grid`, or `Container`, and for design-system primitives when caller context is preferred.
 
 - **`component-attr`** (string, optional): Custom component attribute name (overrides default and native setting)
 
@@ -125,12 +125,12 @@ function IssueActions() {
 }
 ```
 
-In this example, `Flex` is layout plumbing. With `Flex` configured as transparent, the layout wrapper keeps the owning component metadata without reporting itself as the element:
+In this example, `Flex` is layout plumbing. With `Flex` configured as transparent, the layout wrapper records both its owner and its own callsite name without reporting itself as the element:
 
 ```jsx
 function IssueActions() {
   return (
-    <Flex data-sentry-component="IssueActions" data-sentry-source-file="issueActions.tsx">
+    <Flex data-sentry-component="IssueActions-Flex" data-sentry-source-file="issueActions.tsx">
       <Button data-sentry-element="Button" data-sentry-source-file="issueActions.tsx">
         Resolve
       </Button>
@@ -139,13 +139,13 @@ function IssueActions() {
 }
 ```
 
-If the React component `Button` is also configured as transparent, its annotation intentionally collapses to the owner:
+If the React component `Button` is also configured as transparent, it gets the same root owner with its own component name. Transparent wrappers do not accumulate in nested labels:
 
 ```jsx
 function IssueActions() {
   return (
-    <Flex data-sentry-component="IssueActions" data-sentry-source-file="issueActions.tsx">
-      <Button data-sentry-component="IssueActions" data-sentry-source-file="issueActions.tsx">
+    <Flex data-sentry-component="IssueActions-Flex" data-sentry-source-file="issueActions.tsx">
+      <Button data-sentry-component="IssueActions-Button" data-sentry-source-file="issueActions.tsx">
         Resolve
       </Button>
     </Flex>
@@ -163,15 +163,15 @@ const Container = memo(function Container({as: Component = 'div', ...props}) {
 });
 ```
 
-The useful result is that layout DOM points at the owner that rendered it, not at `Flex` or `flex.tsx`:
+The useful result is that layout DOM retains both the owner and the transparent callsite, rather than pointing at `Flex` or `flex.tsx` alone:
 
 ```html
-<div data-sentry-component="IssueActions" data-sentry-source-file="issueActions.tsx">
+<div data-sentry-component="IssueActions-Flex" data-sentry-source-file="issueActions.tsx">
   ...
 </div>
 ```
 
-Whether to include components such as `Button`, `Link`, `Checkbox`, or `MenuItem` depends on the signal you want in the DOM. Leave them out of `transparent-components` when their component name is useful context, for example "the `Button` rendered by `IssueActions`". Include them when the owning component is the preferred label everywhere, for example "the `IssueActions` UI rendered this DOM node".
+Whether to include components such as `Button`, `Link`, `Checkbox`, or `MenuItem` depends on the signal you want in the DOM. Leave them out of `transparent-components` when their component name should be reported as an element. Include them when the combined label is more useful, for example `IssueActions-Button`.
 
 Use `ignored-components` only when a component should not participate in annotation at all. Ignored components get no generated attributes. Use `transparent-components` when a component should still receive useful owner metadata, but should not report itself as `data-sentry-element`.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,14 @@ use jsx_scope::{
 };
 use jsx_utils::*;
 use path_utils::{extract_absolute_path, extract_filename};
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use styled::{styled_call_component_ref, transform_styled_call, StyledTransformAttrs};
 use swc_core::{
     common::{FileName, DUMMY_SP},
     ecma::{
         ast::*,
         atoms::Atom,
-        visit::{noop_visit_mut_type, VisitMut, VisitMutWith},
+        visit::{noop_visit_mut_type, noop_visit_type, Visit, VisitMut, VisitMutWith, VisitWith},
     },
     plugin::{
         metadata::TransformPluginMetadataContextKind, plugin_transform,
@@ -47,6 +47,128 @@ struct ElementAttrs {
     insertion_position: AttributeInsertionPosition,
 }
 
+// React Compiler can cache JSX in temps before forwarding one of them to the
+// value returned from the component. Follow the expressions that preserve a
+// render value without introducing a new one.
+#[derive(Default)]
+struct ReturnRootBindingCollector {
+    returned_identifiers: FxHashSet<Id>,
+    value_sources: FxHashMap<Id, FxHashSet<Id>>,
+}
+
+impl ReturnRootBindingCollector {
+    fn add_value_source(&mut self, target: &BindingIdent, value: &Expr) {
+        let target = target.id.to_id();
+
+        visit_value_source_identifiers(value, &mut |source| {
+            self.value_sources
+                .entry(target.clone())
+                .or_default()
+                .insert(source.to_id());
+        });
+    }
+
+    fn add_returned_value(&mut self, value: &Expr) {
+        visit_value_source_identifiers(value, &mut |source| {
+            self.returned_identifiers.insert(source.to_id());
+        });
+    }
+
+    fn return_root_bindings(self) -> FxHashSet<Id> {
+        let mut bindings = self.returned_identifiers;
+        let mut pending_bindings: Vec<_> = bindings.iter().cloned().collect();
+
+        while let Some(binding) = pending_bindings.pop() {
+            let Some(sources) = self.value_sources.get(&binding) else {
+                continue;
+            };
+
+            for source in sources {
+                if bindings.insert(source.clone()) {
+                    pending_bindings.push(source.clone());
+                }
+            }
+        }
+
+        bindings
+    }
+}
+
+fn visit_value_source_identifiers(value: &Expr, visitor: &mut impl FnMut(&Ident)) {
+    match value {
+        Expr::Ident(ident) => visitor(ident),
+        Expr::Cond(cond) => {
+            visit_value_source_identifiers(&cond.cons, visitor);
+            visit_value_source_identifiers(&cond.alt, visitor);
+        }
+        Expr::Paren(paren) => visit_value_source_identifiers(&paren.expr, visitor),
+        Expr::Seq(seq) => {
+            if let Some(value) = seq.exprs.last() {
+                visit_value_source_identifiers(value, visitor);
+            }
+        }
+        _ => {}
+    }
+}
+
+impl Visit for ReturnRootBindingCollector {
+    noop_visit_type!();
+
+    fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
+
+    fn visit_function(&mut self, _: &Function) {}
+
+    fn visit_assign_expr(&mut self, assign_expr: &AssignExpr) {
+        if assign_expr.op == AssignOp::Assign {
+            if let AssignTarget::Simple(SimpleAssignTarget::Ident(target)) = &assign_expr.left {
+                self.add_value_source(target, &assign_expr.right);
+            }
+        }
+    }
+
+    fn visit_jsx_element(&mut self, _: &JSXElement) {}
+
+    fn visit_jsx_fragment(&mut self, _: &JSXFragment) {}
+
+    fn visit_return_stmt(&mut self, return_stmt: &ReturnStmt) {
+        if let Some(value) = return_stmt.arg.as_deref() {
+            self.add_returned_value(value);
+        }
+    }
+
+    fn visit_var_declarator(&mut self, var_declarator: &VarDeclarator) {
+        if let (Pat::Ident(target), Some(value)) = (&var_declarator.name, &var_declarator.init) {
+            self.add_value_source(target, value);
+        }
+    }
+}
+
+fn returned_value_identifiers_from_block(block: &BlockStmt) -> FxHashSet<Id> {
+    let mut collector = ReturnRootBindingCollector::default();
+    block.visit_with(&mut collector);
+    collector.return_root_bindings()
+}
+
+fn returned_value_identifiers_from_function(function: &Function) -> FxHashSet<Id> {
+    function
+        .body
+        .as_ref()
+        .map(returned_value_identifiers_from_block)
+        .unwrap_or_default()
+}
+
+fn returned_value_identifiers_from_arrow(arrow_expr: &ArrowExpr) -> FxHashSet<Id> {
+    match arrow_expr.body.as_ref() {
+        BlockStmtOrExpr::BlockStmt(block) => returned_value_identifiers_from_block(block),
+        BlockStmtOrExpr::Expr(expr) => match expr.as_ref() {
+            Expr::Ident(ident) => std::iter::once(ident.to_id()).collect(),
+            _ => FxHashSet::default(),
+        },
+        #[cfg(swc_ast_unknown)]
+        _ => panic!("unknown block stmt or expr"),
+    }
+}
+
 pub struct ReactComponentAnnotateVisitor {
     config: PluginConfig,
     source_file_name: Option<Str>,
@@ -54,15 +176,14 @@ pub struct ReactComponentAnnotateVisitor {
     current_component_name: Option<Atom>,
     fragment_child_component_name: Option<Atom>,
     current_return_component_name: Option<Atom>,
-    /// Owner for a render-root JSX element that the React Compiler hoisted out
-    /// of `return` into a memo-cache assignment (`t = <jsx>`), where
-    /// `visit_component_return_expr` no longer sees it.
-    render_root_owner: Option<Atom>,
+    return_root_bindings: FxHashSet<Id>,
+    react_compiler_enabled: bool,
     ignored_elements: &'static FxHashSet<&'static str>,
     ignored_components_set: FxHashSet<String>,
     transparent_components_set: FxHashSet<String>,
     jsx_bindings: JsxBindingTracker,
     fragment_component_identifiers: FxHashSet<Id>,
+    react_memo_identifiers: FxHashSet<Id>,
     react_namespace_identifiers: FxHashSet<Id>,
     component_attr_ident: IdentName,
     element_attr_ident: IdentName,
@@ -115,8 +236,10 @@ impl ReactComponentAnnotateVisitor {
             current_component_name: None,
             fragment_child_component_name: None,
             current_return_component_name: None,
-            render_root_owner: None,
+            return_root_bindings: FxHashSet::default(),
+            react_compiler_enabled: false,
             styled_import: None,
+            react_memo_identifiers: FxHashSet::default(),
         }
     }
 
@@ -291,6 +414,14 @@ impl ReactComponentAnnotateVisitor {
     }
 
     #[inline]
+    fn is_global_react_memo_identifier(&self, ident: &Ident) -> bool {
+        let id = ident.to_id();
+
+        self.scoped_jsx_identifier_status(&id).is_none()
+            && self.react_memo_identifiers.contains(&id)
+    }
+
+    #[inline]
     fn is_unannotatable_jsx_element_name(&self, element_name: &JSXElementName) -> bool {
         let JSXElementName::Ident(ident) = element_name else {
             return false;
@@ -370,9 +501,16 @@ impl ReactComponentAnnotateVisitor {
                         Some(_) => panic!("unknown module export name"),
                     };
 
-                    if imported_name == Some("Fragment") {
-                        self.fragment_component_identifiers
-                            .insert(named_import.local.to_id());
+                    match imported_name {
+                        Some("Fragment") => {
+                            self.fragment_component_identifiers
+                                .insert(named_import.local.to_id());
+                        }
+                        Some("memo") => {
+                            self.react_memo_identifiers
+                                .insert(named_import.local.to_id());
+                        }
+                        _ => {}
                     }
                 }
                 #[cfg(swc_ast_unknown)]
@@ -432,12 +570,23 @@ impl ReactComponentAnnotateVisitor {
     }
 
     fn visit_var_declarator(&mut self, var_declarator: &mut VarDeclarator) {
+        let is_return_root_binding = matches!(
+            &var_declarator.name,
+            Pat::Ident(ident) if self.return_root_bindings.contains(&ident.id.to_id())
+        );
         let component_name = match &var_declarator.name {
             Pat::Ident(ident) => Some(ident.id.sym.clone()),
             _ => None,
         };
 
         var_declarator.name.visit_mut_with(self);
+
+        if is_return_root_binding {
+            if let Some(init) = &mut var_declarator.init {
+                self.visit_component_return_expr(init);
+            }
+            return;
+        }
 
         if component_name.as_ref().is_some_and(|component_name| {
             self.should_skip_component_child_traversal(component_name)
@@ -448,6 +597,12 @@ impl ReactComponentAnnotateVisitor {
         if let Some(init) = &mut var_declarator.init {
             match init.as_mut() {
                 Expr::Call(call_expr) => {
+                    if let Some(component_name) = component_name.clone() {
+                        if self.visit_react_memo_component(call_expr, component_name) {
+                            return;
+                        }
+                    }
+
                     if self.config.experimental_rewrite_emotion_styled {
                         if let (Some(component_name), Some(ref_component_name)) = (
                             component_name.as_ref(),
@@ -542,6 +697,7 @@ impl ReactComponentAnnotateVisitor {
         match item {
             ModuleItem::ModuleDecl(ModuleDecl::Import(import_decl)) => {
                 self.register_react_imports(import_decl);
+                self.react_compiler_enabled |= import_decl.src.value == "react/compiler-runtime";
             }
             ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
                 self.register_decl_bindings(&export_decl.decl);
@@ -566,33 +722,62 @@ impl ReactComponentAnnotateVisitor {
         }
     }
 
-    /// Adopt a pending `render_root_owner` as the owner of this JSX root (see
-    /// the field docs). Taken for the duration so nested children aren't
-    /// mistaken for roots; pass the returned state to `restore_render_root`.
-    fn adopt_render_root(&mut self) -> (Option<Atom>, Option<Option<Atom>>) {
-        let root_owner = self.render_root_owner.take();
-        let restore_component = if self.current_component_name.is_none() {
-            root_owner
-                .as_ref()
-                .map(|owner| self.current_component_name.replace(owner.clone()))
-        } else {
-            None
+    fn is_react_memo_call(&self, call_expr: &CallExpr) -> bool {
+        let Some(callee) = call_expr.callee.as_expr() else {
+            return false;
         };
-        (root_owner, restore_component)
+
+        match callee.as_ref() {
+            Expr::Ident(ident) => self.is_global_react_memo_identifier(ident),
+            Expr::Member(member_expr) => {
+                matches!(&member_expr.prop, MemberProp::Ident(prop) if prop.sym.as_ref() == "memo")
+                    && matches!(
+                        member_expr.obj.as_ref(),
+                        Expr::Ident(obj) if self.is_global_react_namespace_identifier(obj)
+                    )
+            }
+            #[cfg(swc_ast_unknown)]
+            Expr::Unknown(..) => panic!("unknown expr"),
+            _ => false,
+        }
     }
 
-    fn restore_render_root(&mut self, state: (Option<Atom>, Option<Option<Atom>>)) {
-        let (root_owner, restore_component) = state;
-        if let Some(prev_component) = restore_component {
-            self.current_component_name = prev_component;
+    fn visit_react_memo_component(
+        &mut self,
+        call_expr: &mut CallExpr,
+        component_name: Atom,
+    ) -> bool {
+        if !self.is_react_memo_call(call_expr) {
+            return false;
         }
-        // Restore so sibling roots on the same render spine are still adopted.
-        self.render_root_owner = root_owner;
+
+        let Some(component_arg) = call_expr.args.first_mut() else {
+            return false;
+        };
+        if component_arg.spread.is_some() {
+            return false;
+        }
+
+        match component_arg.expr.as_mut() {
+            Expr::Arrow(arrow_expr) => {
+                self.visit_arrow_as_component(arrow_expr, component_name);
+            }
+            Expr::Fn(function_expr) => {
+                self.visit_function_as_component(&mut function_expr.function, component_name);
+            }
+            #[cfg(swc_ast_unknown)]
+            Expr::Unknown(..) => panic!("unknown expr"),
+            _ => return false,
+        }
+
+        for arg in call_expr.args.iter_mut().skip(1) {
+            arg.visit_mut_with(self);
+        }
+
+        true
     }
 
     fn process_jsx_element(&mut self, element: &mut JSXElement) {
-        let render_root = self.adopt_render_root();
-
         // Check if this is a named fragment (Fragment, React.Fragment, or aliases)
         let is_fragment = self.is_react_fragment_element_name(&element.opening.name);
 
@@ -605,14 +790,10 @@ impl ReactComponentAnnotateVisitor {
         } else {
             self.visit_element_jsx_children(element);
         }
-
-        self.restore_render_root(render_root);
     }
 
     fn process_jsx_fragment(&mut self, fragment: &mut JSXFragment) {
-        let render_root = self.adopt_render_root();
         self.visit_fragment_jsx_children(fragment);
-        self.restore_render_root(render_root);
     }
 
     fn visit_fragment_jsx_children<N>(&mut self, node: &mut N)
@@ -700,8 +881,12 @@ impl ReactComponentAnnotateVisitor {
         let prev_return_component = self.current_return_component_name.replace(component_name);
         let prev_component = self.current_component_name.take();
         let prev_fragment_child_component = self.fragment_child_component_name.take();
-        let prev_render_root = self.render_root_owner.clone();
-        self.render_root_owner = self.current_return_component_name.clone();
+        let prev_return_root_bindings = std::mem::replace(
+            &mut self.return_root_bindings,
+            self.react_compiler_enabled
+                .then(|| returned_value_identifiers_from_function(func))
+                .unwrap_or_default(),
+        );
 
         self.jsx_bindings
             .push_function_with(collect_function_param_scope(&func.params));
@@ -711,7 +896,7 @@ impl ReactComponentAnnotateVisitor {
         self.current_return_component_name = prev_return_component;
         self.current_component_name = prev_component;
         self.fragment_child_component_name = prev_fragment_child_component;
-        self.render_root_owner = prev_render_root;
+        self.return_root_bindings = prev_return_root_bindings;
     }
 
     fn visit_arrow_as_component(&mut self, arrow_expr: &mut ArrowExpr, component_name: Atom) {
@@ -722,8 +907,12 @@ impl ReactComponentAnnotateVisitor {
         let prev_return_component = self.current_return_component_name.replace(component_name);
         let prev_component = self.current_component_name.take();
         let prev_fragment_child_component = self.fragment_child_component_name.take();
-        let prev_render_root = self.render_root_owner.clone();
-        self.render_root_owner = self.current_return_component_name.clone();
+        let prev_return_root_bindings = std::mem::replace(
+            &mut self.return_root_bindings,
+            self.react_compiler_enabled
+                .then(|| returned_value_identifiers_from_arrow(arrow_expr))
+                .unwrap_or_default(),
+        );
 
         self.jsx_bindings
             .push_function_with(collect_pat_list_scope(&arrow_expr.params));
@@ -742,7 +931,7 @@ impl ReactComponentAnnotateVisitor {
         self.current_return_component_name = prev_return_component;
         self.current_component_name = prev_component;
         self.fragment_child_component_name = prev_fragment_child_component;
-        self.render_root_owner = prev_render_root;
+        self.return_root_bindings = prev_return_root_bindings;
     }
 
     fn visit_component_return_expr(&mut self, expr: &mut Expr) {
@@ -842,7 +1031,7 @@ impl VisitMut for ReactComponentAnnotateVisitor {
         let prev_return_component = self.current_return_component_name.take();
         let prev_component = self.current_component_name.take();
         let prev_fragment_child_component = self.fragment_child_component_name.take();
-        let prev_render_root = self.render_root_owner.take();
+        let prev_return_root_bindings = std::mem::take(&mut self.return_root_bindings);
 
         self.jsx_bindings
             .push_function_with(collect_function_param_scope(&function.params));
@@ -852,7 +1041,7 @@ impl VisitMut for ReactComponentAnnotateVisitor {
         self.current_return_component_name = prev_return_component;
         self.current_component_name = prev_component;
         self.fragment_child_component_name = prev_fragment_child_component;
-        self.render_root_owner = prev_render_root;
+        self.return_root_bindings = prev_return_root_bindings;
     }
 
     fn visit_mut_var_decl(&mut self, var_decl: &mut VarDecl) {
@@ -926,7 +1115,7 @@ impl VisitMut for ReactComponentAnnotateVisitor {
         let prev_return_component = self.current_return_component_name.take();
         let prev_component = self.current_component_name.take();
         let prev_fragment_child_component = self.fragment_child_component_name.take();
-        let prev_render_root = self.render_root_owner.take();
+        let prev_return_root_bindings = std::mem::take(&mut self.return_root_bindings);
 
         self.jsx_bindings
             .push_function_with(collect_pat_list_scope(&arrow_expr.params));
@@ -936,7 +1125,22 @@ impl VisitMut for ReactComponentAnnotateVisitor {
         self.current_return_component_name = prev_return_component;
         self.current_component_name = prev_component;
         self.fragment_child_component_name = prev_fragment_child_component;
-        self.render_root_owner = prev_render_root;
+        self.return_root_bindings = prev_return_root_bindings;
+    }
+
+    fn visit_mut_assign_expr(&mut self, assign_expr: &mut AssignExpr) {
+        let is_return_root_assignment = assign_expr.op == AssignOp::Assign
+            && matches!(
+                &assign_expr.left,
+                AssignTarget::Simple(SimpleAssignTarget::Ident(ident))
+                    if self.return_root_bindings.contains(&ident.id.to_id())
+            );
+
+        if is_return_root_assignment {
+            self.visit_component_return_expr(&mut assign_expr.right);
+        } else {
+            assign_expr.visit_mut_children_with(self);
+        }
     }
 
     fn visit_mut_return_stmt(&mut self, return_stmt: &mut ReturnStmt) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1117,8 +1117,6 @@ impl VisitMut for ReactComponentAnnotateVisitor {
     }
 
     fn visit_mut_import_decl(&mut self, import_decl: &mut ImportDecl) {
-        self.register_react_imports(import_decl);
-
         // Track imports from @emotion/styled (only if enabled)
         if self.config.experimental_rewrite_emotion_styled
             && import_decl.src.value == "@emotion/styled"
@@ -1307,11 +1305,6 @@ impl VisitMut for ReactComponentAnnotateVisitor {
 fn is_react_compiler_temp(name: &str) -> bool {
     name.strip_prefix("_temp")
         .is_some_and(|rest| rest.bytes().all(|byte| byte.is_ascii_digit()))
-}
-
-// Export for testing
-pub fn extract_filename_for_test(filename: &FileName) -> Option<String> {
-    extract_filename(filename)
 }
 
 #[plugin_transform]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,13 +48,6 @@ struct ElementAttrs {
 }
 
 type DefinitionId = usize;
-type ReachingDefinitions = FxHashMap<Id, FxHashSet<DefinitionId>>;
-type ReachingDefinitionChanges = FxHashMap<Id, Option<FxHashSet<DefinitionId>>>;
-
-struct BranchDefinitions {
-    changed: ReachingDefinitions,
-    reachable: bool,
-}
 
 #[derive(Default)]
 struct ReturnRootDefinitions {
@@ -75,211 +68,139 @@ impl ReturnRootDefinitions {
     }
 }
 
-// React Compiler caches JSX in local definitions before returning it. Track
-// the exact reaching definitions so a later reassignment of the same binding
-// does not become part of an earlier returned value.
+struct Definition {
+    sources: Vec<Id>,
+    contains_jsx: bool,
+}
+
+// React Compiler caches JSX in local definitions before returning it. Resolve
+// aliases to the latest earlier definition that contains JSX or forwards
+// another identifier. Cache restore assignments such as `t1 = $[0]` are not
+// value origins and are intentionally skipped.
 #[derive(Default)]
 struct ReturnRootDefinitionCollector {
-    reaching: ReachingDefinitions,
-    definition_sources: Vec<FxHashSet<DefinitionId>>,
-    returned_definitions: FxHashSet<DefinitionId>,
-    break_environments: Vec<Vec<ReachingDefinitions>>,
-    reaching_changes: Vec<ReachingDefinitionChanges>,
-    reachable: bool,
+    definitions: Vec<Definition>,
+    definitions_by_binding: FxHashMap<Id, Vec<DefinitionId>>,
+    returned_values: Vec<(Id, DefinitionId)>,
 }
 
 impl ReturnRootDefinitionCollector {
-    fn new() -> Self {
-        Self {
-            reachable: true,
-            ..Self::default()
-        }
-    }
-
-    fn reserve_definition(&mut self) -> DefinitionId {
-        let definition = self.definition_sources.len();
-        self.definition_sources.push(FxHashSet::default());
-        definition
-    }
-
-    fn value_definitions(&self, value: &Expr) -> FxHashSet<DefinitionId> {
-        let mut definitions = FxHashSet::default();
-        visit_value_source_identifiers(value, &mut |source| {
-            if let Some(reaching) = self.reaching.get(&source.to_id()) {
-                definitions.extend(reaching);
-            }
+    fn add_definition(&mut self, target: &BindingIdent, value: &Expr) {
+        let id = self.definitions.len();
+        let mut sources = Vec::new();
+        let contains_jsx = collect_value_sources(value, &mut sources);
+        self.definitions.push(Definition {
+            sources,
+            contains_jsx,
         });
-        definitions
+        self.definitions_by_binding
+            .entry(target.id.to_id())
+            .or_default()
+            .push(id);
     }
 
-    fn record_definition(&mut self, definition: DefinitionId, target: &BindingIdent, value: &Expr) {
-        if !self.reachable {
+    fn add_returned_value(&mut self, value: &Expr) {
+        let before = self.definitions.len();
+        let mut sources = Vec::new();
+        collect_value_sources(value, &mut sources);
+        self.returned_values
+            .extend(sources.into_iter().map(|source| (source, before)));
+    }
+
+    fn resolve(&self, binding: &Id, before: DefinitionId, roots: &mut FxHashSet<DefinitionId>) {
+        let Some(definition) = self
+            .definitions_by_binding
+            .get(binding)
+            .and_then(|definitions| {
+                definitions.iter().rev().copied().find(|definition| {
+                    *definition < before
+                        && (self.definitions[*definition].contains_jsx
+                            || !self.definitions[*definition].sources.is_empty())
+                })
+            })
+        else {
+            return;
+        };
+
+        if !roots.insert(definition) {
             return;
         }
-
-        self.definition_sources[definition] = self.value_definitions(value);
-        self.set_reaching(target.id.to_id(), std::iter::once(definition).collect());
-    }
-
-    fn set_reaching(&mut self, binding: Id, definitions: FxHashSet<DefinitionId>) {
-        let previous = self.reaching.get(&binding).cloned();
-        if let Some(changes) = self.reaching_changes.last_mut() {
-            changes.entry(binding.clone()).or_insert(previous);
+        for source in &self.definitions[definition].sources {
+            self.resolve(source, definition, roots);
         }
-        self.reaching.insert(binding, definitions);
-    }
-
-    fn begin_branch(&mut self) {
-        self.reaching_changes
-            .push(ReachingDefinitionChanges::default());
-    }
-
-    fn finish_branch(&mut self) -> BranchDefinitions {
-        let changes = self.reaching_changes.pop().unwrap_or_default();
-        let mut changed = ReachingDefinitions::default();
-
-        for (binding, previous) in changes {
-            if let Some(definitions) = self.reaching.get(&binding) {
-                changed.insert(binding.clone(), definitions.clone());
-            }
-
-            match previous {
-                Some(definitions) => {
-                    self.reaching.insert(binding, definitions);
-                }
-                None => {
-                    self.reaching.remove(&binding);
-                }
-            }
-        }
-
-        BranchDefinitions {
-            changed,
-            reachable: self.reachable,
-        }
-    }
-
-    fn merge_branches(&mut self, consequent: BranchDefinitions, alternate: BranchDefinitions) {
-        let mut changed_bindings: FxHashSet<_> = consequent.changed.keys().cloned().collect();
-        changed_bindings.extend(alternate.changed.keys().cloned());
-
-        for binding in changed_bindings {
-            let mut definitions = FxHashSet::default();
-            if consequent.reachable {
-                if let Some(changed) = consequent.changed.get(&binding) {
-                    definitions.extend(changed);
-                } else if let Some(input) = self.reaching.get(&binding) {
-                    definitions.extend(input);
-                }
-            }
-            if alternate.reachable {
-                if let Some(changed) = alternate.changed.get(&binding) {
-                    definitions.extend(changed);
-                } else if let Some(input) = self.reaching.get(&binding) {
-                    definitions.extend(input);
-                }
-            }
-            self.set_reaching(binding, definitions);
-        }
-
-        self.reachable = consequent.reachable || alternate.reachable;
-    }
-
-    fn begin_loop(&mut self) {
-        self.break_environments.push(Vec::new());
-        self.begin_branch();
-    }
-
-    fn finish_loop(&mut self, body: BranchDefinitions, can_skip: bool, input_reachable: bool) {
-        self.merge_branches(
-            body,
-            BranchDefinitions {
-                changed: ReachingDefinitions::default(),
-                reachable: can_skip && input_reachable,
-            },
-        );
-
-        let break_environments = self.break_environments.pop().unwrap_or_default();
-        let has_break = !break_environments.is_empty();
-        for environment in break_environments {
-            for (binding, break_definitions) in environment {
-                let mut definitions = self.reaching.get(&binding).cloned().unwrap_or_default();
-                definitions.extend(break_definitions);
-                self.set_reaching(binding, definitions);
-            }
-        }
-        self.reachable |= has_break;
     }
 
     fn finish(self) -> ReturnRootDefinitions {
-        let definition_count = self.definition_sources.len();
-        let mut roots = self.returned_definitions;
-        let mut pending: Vec<_> = roots.iter().copied().collect();
-
-        while let Some(definition) = pending.pop() {
-            for source in &self.definition_sources[definition] {
-                if roots.insert(*source) {
-                    pending.push(*source);
-                }
-            }
+        let mut roots = FxHashSet::default();
+        for (binding, before) in &self.returned_values {
+            self.resolve(binding, *before, &mut roots);
         }
 
         ReturnRootDefinitions {
             roots,
-            definition_count,
+            definition_count: self.definitions.len(),
             next_definition: 0,
         }
     }
 }
 
-fn visit_value_source_identifiers(value: &Expr, visitor: &mut impl FnMut(&Ident)) {
+fn collect_value_sources(value: &Expr, sources: &mut Vec<Id>) -> bool {
     match value {
-        Expr::Ident(ident) => visitor(ident),
+        Expr::Ident(ident) => {
+            sources.push(ident.to_id());
+            false
+        }
+        Expr::JSXElement(element) => {
+            collect_jsx_child_sources(&element.children, sources);
+            true
+        }
+        Expr::JSXFragment(fragment) => {
+            collect_jsx_child_sources(&fragment.children, sources);
+            true
+        }
         Expr::Bin(binary)
             if matches!(
                 binary.op,
                 BinaryOp::LogicalAnd | BinaryOp::LogicalOr | BinaryOp::NullishCoalescing
             ) =>
         {
-            visit_value_source_identifiers(&binary.left, visitor);
-            visit_value_source_identifiers(&binary.right, visitor);
+            collect_value_sources(&binary.left, sources)
+                | collect_value_sources(&binary.right, sources)
         }
         Expr::Cond(cond) => {
-            visit_value_source_identifiers(&cond.cons, visitor);
-            visit_value_source_identifiers(&cond.alt, visitor);
+            collect_value_sources(&cond.cons, sources) | collect_value_sources(&cond.alt, sources)
         }
-        Expr::Paren(paren) => visit_value_source_identifiers(&paren.expr, visitor),
-        Expr::Seq(seq) => {
-            if let Some(value) = seq.exprs.last() {
-                visit_value_source_identifiers(value, visitor);
-            }
-        }
-        Expr::TsAs(ts_as) => visit_value_source_identifiers(&ts_as.expr, visitor),
-        Expr::TsConstAssertion(assertion) => {
-            visit_value_source_identifiers(&assertion.expr, visitor);
-        }
-        Expr::TsInstantiation(instantiation) => {
-            visit_value_source_identifiers(&instantiation.expr, visitor);
-        }
-        Expr::TsNonNull(non_null) => visit_value_source_identifiers(&non_null.expr, visitor),
-        Expr::TsSatisfies(satisfies) => {
-            visit_value_source_identifiers(&satisfies.expr, visitor);
-        }
-        Expr::TsTypeAssertion(assertion) => {
-            visit_value_source_identifiers(&assertion.expr, visitor);
-        }
-        _ => {}
+        Expr::Paren(paren) => collect_value_sources(&paren.expr, sources),
+        Expr::Seq(seq) => seq
+            .exprs
+            .last()
+            .is_some_and(|value| collect_value_sources(value, sources)),
+        _ => false,
     }
 }
 
-fn merge_reaching_definitions(
-    mut left: ReachingDefinitions,
-    right: ReachingDefinitions,
-) -> ReachingDefinitions {
-    for (binding, definitions) in right {
-        left.entry(binding).or_default().extend(definitions);
+fn collect_jsx_child_sources(children: &[JSXElementChild], sources: &mut Vec<Id>) {
+    for child in children {
+        match child {
+            JSXElementChild::JSXExprContainer(container) => {
+                if let JSXExpr::Expr(expr) = &container.expr {
+                    collect_value_sources(expr, sources);
+                }
+            }
+            JSXElementChild::JSXSpreadChild(spread) => {
+                collect_value_sources(&spread.expr, sources);
+            }
+            JSXElementChild::JSXElement(element) => {
+                collect_jsx_child_sources(&element.children, sources);
+            }
+            JSXElementChild::JSXFragment(fragment) => {
+                collect_jsx_child_sources(&fragment.children, sources);
+            }
+            JSXElementChild::JSXText(_) => {}
+            #[cfg(swc_ast_unknown)]
+            _ => panic!("unknown jsx element child"),
+        }
     }
-    left
 }
 
 impl Visit for ReturnRootDefinitionCollector {
@@ -287,181 +208,39 @@ impl Visit for ReturnRootDefinitionCollector {
 
     fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
 
-    fn visit_break_stmt(&mut self, _: &BreakStmt) {
-        if !self.reachable {
-            return;
-        }
-
-        if let Some(environments) = self.break_environments.last_mut() {
-            environments.push(std::mem::take(&mut self.reaching));
-            self.reachable = false;
-        }
-    }
-
     fn visit_function(&mut self, _: &Function) {}
 
-    fn visit_for_in_stmt(&mut self, for_in_stmt: &ForInStmt) {
-        for_in_stmt.left.visit_with(self);
-        for_in_stmt.right.visit_with(self);
-        let input_reachable = self.reachable;
-
-        self.begin_loop();
-        for_in_stmt.body.visit_with(self);
-        let body = self.finish_branch();
-        self.finish_loop(body, true, input_reachable);
-    }
-
-    fn visit_for_of_stmt(&mut self, for_of_stmt: &ForOfStmt) {
-        for_of_stmt.left.visit_with(self);
-        for_of_stmt.right.visit_with(self);
-        let input_reachable = self.reachable;
-
-        self.begin_loop();
-        for_of_stmt.body.visit_with(self);
-        let body = self.finish_branch();
-        self.finish_loop(body, true, input_reachable);
-    }
-
-    fn visit_for_stmt(&mut self, for_stmt: &ForStmt) {
-        for_stmt.init.visit_with(self);
-        for_stmt.test.visit_with(self);
-        let input_reachable = self.reachable;
-
-        self.begin_loop();
-        for_stmt.update.visit_with(self);
-        for_stmt.body.visit_with(self);
-        let body = self.finish_branch();
-        self.finish_loop(body, true, input_reachable);
-    }
-
     fn visit_assign_expr(&mut self, assign_expr: &AssignExpr) {
-        let AssignTarget::Simple(SimpleAssignTarget::Ident(target)) = &assign_expr.left else {
-            assign_expr.visit_children_with(self);
-            return;
-        };
-        if assign_expr.op != AssignOp::Assign {
-            assign_expr.visit_children_with(self);
-            return;
+        let definition = matches!(
+            &assign_expr.left,
+            AssignTarget::Simple(SimpleAssignTarget::Ident(_))
+        ) && assign_expr.op == AssignOp::Assign;
+        if definition {
+            let AssignTarget::Simple(SimpleAssignTarget::Ident(target)) = &assign_expr.left else {
+                unreachable!();
+            };
+            self.add_definition(target, &assign_expr.right);
         }
-
-        let definition = self.reserve_definition();
-        assign_expr.right.visit_with(self);
-        self.record_definition(definition, target, &assign_expr.right);
-    }
-
-    fn visit_if_stmt(&mut self, if_stmt: &IfStmt) {
-        if_stmt.test.visit_with(self);
-        let branch_reachable = self.reachable;
-
-        self.begin_branch();
-        if_stmt.cons.visit_with(self);
-        let consequent = self.finish_branch();
-
-        self.reachable = branch_reachable;
-        self.begin_branch();
-        if let Some(alternate) = &if_stmt.alt {
-            alternate.visit_with(self);
-        }
-        let alternate = self.finish_branch();
-
-        self.merge_branches(consequent, alternate);
+        assign_expr.visit_children_with(self);
     }
 
     fn visit_return_stmt(&mut self, return_stmt: &ReturnStmt) {
         if let Some(value) = return_stmt.arg.as_deref() {
             value.visit_with(self);
-            if self.reachable {
-                self.returned_definitions
-                    .extend(self.value_definitions(value));
-            }
+            self.add_returned_value(value);
         }
-        self.reachable = false;
-    }
-
-    fn visit_switch_stmt(&mut self, switch_stmt: &SwitchStmt) {
-        switch_stmt.discriminant.visit_with(self);
-        let switch_input = self.reaching.clone();
-        let switch_reachable = self.reachable;
-        let has_default = switch_stmt.cases.iter().any(|case| case.test.is_none());
-        let mut fallthrough = None;
-
-        self.break_environments.push(Vec::new());
-
-        for case in &switch_stmt.cases {
-            self.reaching = if let Some(fallthrough) = fallthrough.take() {
-                if switch_reachable {
-                    merge_reaching_definitions(switch_input.clone(), fallthrough)
-                } else {
-                    fallthrough
-                }
-            } else {
-                switch_input.clone()
-            };
-            self.reachable = switch_reachable || !self.reaching.is_empty();
-
-            if let Some(test) = &case.test {
-                test.visit_with(self);
-            }
-            for statement in &case.cons {
-                statement.visit_with(self);
-            }
-
-            if self.reachable {
-                fallthrough = Some(std::mem::take(&mut self.reaching));
-            }
-        }
-
-        let mut exits = self.break_environments.pop().unwrap_or_default();
-        if let Some(fallthrough) = fallthrough {
-            exits.push(fallthrough);
-        }
-        if switch_reachable && !has_default {
-            exits.push(switch_input);
-        }
-
-        let switch_reachable = !exits.is_empty();
-        let mut exits = exits.into_iter();
-        self.reaching = exits.next().unwrap_or_default();
-        for exit in exits {
-            self.reaching = merge_reaching_definitions(std::mem::take(&mut self.reaching), exit);
-        }
-        self.reachable = switch_reachable;
     }
 
     fn visit_var_declarator(&mut self, var_declarator: &VarDeclarator) {
-        let (Pat::Ident(target), Some(value)) = (&var_declarator.name, &var_declarator.init) else {
-            var_declarator.visit_children_with(self);
-            return;
-        };
-
-        let definition = self.reserve_definition();
-        value.visit_with(self);
-        self.record_definition(definition, target, value);
-    }
-
-    fn visit_while_stmt(&mut self, while_stmt: &WhileStmt) {
-        while_stmt.test.visit_with(self);
-        let input_reachable = self.reachable;
-
-        self.begin_loop();
-        while_stmt.body.visit_with(self);
-        let body = self.finish_branch();
-        self.finish_loop(body, true, input_reachable);
-    }
-
-    fn visit_do_while_stmt(&mut self, do_while_stmt: &DoWhileStmt) {
-        do_while_stmt.test.visit_with(self);
-        let input_reachable = self.reachable;
-
-        self.begin_loop();
-        do_while_stmt.body.visit_with(self);
-        let body = self.finish_branch();
-        self.finish_loop(body, false, input_reachable);
+        if let (Pat::Ident(target), Some(value)) = (&var_declarator.name, &var_declarator.init) {
+            self.add_definition(target, value);
+        }
+        var_declarator.visit_children_with(self);
     }
 }
 
 fn return_root_definitions_from_block(block: &BlockStmt) -> ReturnRootDefinitions {
-    let mut collector = ReturnRootDefinitionCollector::new();
+    let mut collector = ReturnRootDefinitionCollector::default();
     block.visit_with(&mut collector);
     collector.finish()
 }
@@ -478,11 +257,9 @@ fn return_root_definitions_from_arrow(arrow_expr: &ArrowExpr) -> ReturnRootDefin
     match arrow_expr.body.as_ref() {
         BlockStmtOrExpr::BlockStmt(block) => return_root_definitions_from_block(block),
         BlockStmtOrExpr::Expr(expr) => {
-            let mut collector = ReturnRootDefinitionCollector::new();
+            let mut collector = ReturnRootDefinitionCollector::default();
             expr.visit_with(&mut collector);
-            collector
-                .returned_definitions
-                .extend(collector.value_definitions(expr));
+            collector.add_returned_value(expr);
             collector.finish()
         }
         #[cfg(swc_ast_unknown)]
@@ -894,53 +671,9 @@ impl ReactComponentAnnotateVisitor {
             "react/compiler-runtime" => {
                 self.react_compiler_enabled = true;
             }
-            "react" => self.register_commonjs_react_pattern(&declarator.name),
-            _ => {}
-        }
-    }
-
-    fn register_commonjs_react_pattern(&mut self, pattern: &Pat) {
-        match pattern {
-            Pat::Ident(ident) => {
-                self.react_namespace_identifiers.insert(ident.id.to_id());
-            }
-            Pat::Object(object) => {
-                for property in &object.props {
-                    match property {
-                        ObjectPatProp::KeyValue(key_value) => {
-                            let imported_name = match &key_value.key {
-                                PropName::Ident(ident) => Some(ident.sym.as_ref()),
-                                PropName::Str(str) => str.value.as_str(),
-                                _ => None,
-                            };
-                            let Pat::Ident(local) = key_value.value.as_ref() else {
-                                continue;
-                            };
-
-                            match imported_name {
-                                Some("Fragment") => {
-                                    self.fragment_component_identifiers.insert(local.id.to_id());
-                                }
-                                Some("memo") => {
-                                    self.react_memo_identifiers.insert(local.id.to_id());
-                                }
-                                _ => {}
-                            }
-                        }
-                        ObjectPatProp::Assign(assign) => match assign.key.id.sym.as_ref() {
-                            "Fragment" => {
-                                self.fragment_component_identifiers
-                                    .insert(assign.key.id.to_id());
-                            }
-                            "memo" => {
-                                self.react_memo_identifiers.insert(assign.key.id.to_id());
-                            }
-                            _ => {}
-                        },
-                        ObjectPatProp::Rest(_) => {}
-                        #[cfg(swc_ast_unknown)]
-                        _ => panic!("unknown object pattern prop"),
-                    }
+            "react" => {
+                if let Pat::Ident(ident) = &declarator.name {
+                    self.react_namespace_identifiers.insert(ident.id.to_id());
                 }
             }
             _ => {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,9 @@ impl ReactComponentAnnotateVisitor {
     fn element_attrs(
         &self,
         element_name: &str,
+        element_policy: ComponentAnnotationPolicy,
         existing_attrs: &AttributePresence,
+        transparent_owner_component_name: Option<&Atom>,
     ) -> Option<ElementAttrs> {
         if let Some(ref component_name) = self.current_component_name {
             if self.should_skip_component_return(component_name) {
@@ -169,20 +171,17 @@ impl ReactComponentAnnotateVisitor {
             }
         }
 
-        let element_policy = self.component_annotation_policy(element_name);
         if element_policy == ComponentAnnotationPolicy::Ignored {
             return None;
         }
 
         let can_annotate_element = !self.should_ignore_element(element_name)
             && element_policy == ComponentAnnotationPolicy::Normal;
-        let owner_component_name = self.current_component_name.as_ref().or_else(|| {
-            if element_policy == ComponentAnnotationPolicy::Transparent {
-                self.fragment_child_component_name.as_ref()
-            } else {
-                None
-            }
-        });
+        let owner_component_name = if element_policy == ComponentAnnotationPolicy::Transparent {
+            transparent_owner_component_name
+        } else {
+            self.current_component_name.as_ref()
+        };
         let has_owner_component = owner_component_name.is_some();
 
         let mut attrs = Vec::with_capacity(4);
@@ -239,6 +238,20 @@ impl ReactComponentAnnotateVisitor {
                 AttributeInsertionPosition::Append
             },
         })
+    }
+
+    fn transparent_owner_component_name(&self, element_name: &str) -> Option<Atom> {
+        let owner_component_name = self
+            .current_component_name
+            .as_ref()
+            .or(self.fragment_child_component_name.as_ref())?;
+        let owner_component_name = owner_component_name.as_ref();
+        let mut transparent_owner =
+            String::with_capacity(owner_component_name.len() + 1 + element_name.len());
+        transparent_owner.push_str(owner_component_name);
+        transparent_owner.push('-');
+        transparent_owner.push_str(element_name);
+        Some(transparent_owner.into())
     }
 
     #[inline]
@@ -638,6 +651,13 @@ impl ReactComponentAnnotateVisitor {
         }
 
         let element_name = get_element_name(&opening_element.name);
+        let element_policy = self.component_annotation_policy(&element_name);
+        let transparent_owner_component_name =
+            if element_policy == ComponentAnnotationPolicy::Transparent {
+                self.transparent_owner_component_name(&element_name)
+            } else {
+                None
+            };
 
         let existing_attrs = attribute_presence(
             opening_element,
@@ -646,7 +666,12 @@ impl ReactComponentAnnotateVisitor {
             &self.source_file_attr_ident,
             self.source_path_attr_ident.as_ref(),
         );
-        let Some(element_attrs) = self.element_attrs(&element_name, &existing_attrs) else {
+        let Some(element_attrs) = self.element_attrs(
+            &element_name,
+            element_policy,
+            &existing_attrs,
+            transparent_owner_component_name.as_ref(),
+        ) else {
             return;
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,56 +47,203 @@ struct ElementAttrs {
     insertion_position: AttributeInsertionPosition,
 }
 
-// React Compiler can cache JSX in temps before forwarding one of them to the
-// value returned from the component. Follow the expressions that preserve a
-// render value without introducing a new one.
-#[derive(Default)]
-struct ReturnRootBindingCollector {
-    returned_identifiers: FxHashSet<Id>,
-    value_sources: FxHashMap<Id, FxHashSet<Id>>,
+type DefinitionId = usize;
+type ReachingDefinitions = FxHashMap<Id, FxHashSet<DefinitionId>>;
+type ReachingDefinitionChanges = FxHashMap<Id, Option<FxHashSet<DefinitionId>>>;
+
+struct BranchDefinitions {
+    changed: ReachingDefinitions,
+    reachable: bool,
 }
 
-impl ReturnRootBindingCollector {
-    fn add_value_source(&mut self, target: &BindingIdent, value: &Expr) {
-        let target = target.id.to_id();
+#[derive(Default)]
+struct ReturnRootDefinitions {
+    roots: FxHashSet<DefinitionId>,
+    definition_count: usize,
+    next_definition: DefinitionId,
+}
 
-        visit_value_source_identifiers(value, &mut |source| {
-            self.value_sources
-                .entry(target.clone())
-                .or_default()
-                .insert(source.to_id());
-        });
+impl ReturnRootDefinitions {
+    fn next_is_root(&mut self) -> bool {
+        if self.next_definition >= self.definition_count {
+            return false;
+        }
+
+        let definition = self.next_definition;
+        self.next_definition += 1;
+        self.roots.contains(&definition)
+    }
+}
+
+// React Compiler caches JSX in local definitions before returning it. Track
+// the exact reaching definitions so a later reassignment of the same binding
+// does not become part of an earlier returned value.
+#[derive(Default)]
+struct ReturnRootDefinitionCollector {
+    reaching: ReachingDefinitions,
+    definition_sources: Vec<FxHashSet<DefinitionId>>,
+    returned_definitions: FxHashSet<DefinitionId>,
+    break_environments: Vec<Vec<ReachingDefinitions>>,
+    reaching_changes: Vec<ReachingDefinitionChanges>,
+    reachable: bool,
+}
+
+impl ReturnRootDefinitionCollector {
+    fn new() -> Self {
+        Self {
+            reachable: true,
+            ..Self::default()
+        }
     }
 
-    fn add_returned_value(&mut self, value: &Expr) {
-        visit_value_source_identifiers(value, &mut |source| {
-            self.returned_identifiers.insert(source.to_id());
-        });
+    fn reserve_definition(&mut self) -> DefinitionId {
+        let definition = self.definition_sources.len();
+        self.definition_sources.push(FxHashSet::default());
+        definition
     }
 
-    fn return_root_bindings(self) -> FxHashSet<Id> {
-        let mut bindings = self.returned_identifiers;
-        let mut pending_bindings: Vec<_> = bindings.iter().cloned().collect();
+    fn value_definitions(&self, value: &Expr) -> FxHashSet<DefinitionId> {
+        let mut definitions = FxHashSet::default();
+        visit_value_source_identifiers(value, &mut |source| {
+            if let Some(reaching) = self.reaching.get(&source.to_id()) {
+                definitions.extend(reaching);
+            }
+        });
+        definitions
+    }
 
-        while let Some(binding) = pending_bindings.pop() {
-            let Some(sources) = self.value_sources.get(&binding) else {
-                continue;
-            };
+    fn record_definition(&mut self, definition: DefinitionId, target: &BindingIdent, value: &Expr) {
+        if !self.reachable {
+            return;
+        }
 
-            for source in sources {
-                if bindings.insert(source.clone()) {
-                    pending_bindings.push(source.clone());
+        self.definition_sources[definition] = self.value_definitions(value);
+        self.set_reaching(target.id.to_id(), std::iter::once(definition).collect());
+    }
+
+    fn set_reaching(&mut self, binding: Id, definitions: FxHashSet<DefinitionId>) {
+        let previous = self.reaching.get(&binding).cloned();
+        if let Some(changes) = self.reaching_changes.last_mut() {
+            changes.entry(binding.clone()).or_insert(previous);
+        }
+        self.reaching.insert(binding, definitions);
+    }
+
+    fn begin_branch(&mut self) {
+        self.reaching_changes
+            .push(ReachingDefinitionChanges::default());
+    }
+
+    fn finish_branch(&mut self) -> BranchDefinitions {
+        let changes = self.reaching_changes.pop().unwrap_or_default();
+        let mut changed = ReachingDefinitions::default();
+
+        for (binding, previous) in changes {
+            if let Some(definitions) = self.reaching.get(&binding) {
+                changed.insert(binding.clone(), definitions.clone());
+            }
+
+            match previous {
+                Some(definitions) => {
+                    self.reaching.insert(binding, definitions);
+                }
+                None => {
+                    self.reaching.remove(&binding);
                 }
             }
         }
 
-        bindings
+        BranchDefinitions {
+            changed,
+            reachable: self.reachable,
+        }
+    }
+
+    fn merge_branches(&mut self, consequent: BranchDefinitions, alternate: BranchDefinitions) {
+        let mut changed_bindings: FxHashSet<_> = consequent.changed.keys().cloned().collect();
+        changed_bindings.extend(alternate.changed.keys().cloned());
+
+        for binding in changed_bindings {
+            let mut definitions = FxHashSet::default();
+            if consequent.reachable {
+                if let Some(changed) = consequent.changed.get(&binding) {
+                    definitions.extend(changed);
+                } else if let Some(input) = self.reaching.get(&binding) {
+                    definitions.extend(input);
+                }
+            }
+            if alternate.reachable {
+                if let Some(changed) = alternate.changed.get(&binding) {
+                    definitions.extend(changed);
+                } else if let Some(input) = self.reaching.get(&binding) {
+                    definitions.extend(input);
+                }
+            }
+            self.set_reaching(binding, definitions);
+        }
+
+        self.reachable = consequent.reachable || alternate.reachable;
+    }
+
+    fn begin_loop(&mut self) {
+        self.break_environments.push(Vec::new());
+        self.begin_branch();
+    }
+
+    fn finish_loop(&mut self, body: BranchDefinitions, can_skip: bool, input_reachable: bool) {
+        self.merge_branches(
+            body,
+            BranchDefinitions {
+                changed: ReachingDefinitions::default(),
+                reachable: can_skip && input_reachable,
+            },
+        );
+
+        let break_environments = self.break_environments.pop().unwrap_or_default();
+        let has_break = !break_environments.is_empty();
+        for environment in break_environments {
+            for (binding, break_definitions) in environment {
+                let mut definitions = self.reaching.get(&binding).cloned().unwrap_or_default();
+                definitions.extend(break_definitions);
+                self.set_reaching(binding, definitions);
+            }
+        }
+        self.reachable |= has_break;
+    }
+
+    fn finish(self) -> ReturnRootDefinitions {
+        let definition_count = self.definition_sources.len();
+        let mut roots = self.returned_definitions;
+        let mut pending: Vec<_> = roots.iter().copied().collect();
+
+        while let Some(definition) = pending.pop() {
+            for source in &self.definition_sources[definition] {
+                if roots.insert(*source) {
+                    pending.push(*source);
+                }
+            }
+        }
+
+        ReturnRootDefinitions {
+            roots,
+            definition_count,
+            next_definition: 0,
+        }
     }
 }
 
 fn visit_value_source_identifiers(value: &Expr, visitor: &mut impl FnMut(&Ident)) {
     match value {
         Expr::Ident(ident) => visitor(ident),
+        Expr::Bin(binary)
+            if matches!(
+                binary.op,
+                BinaryOp::LogicalAnd | BinaryOp::LogicalOr | BinaryOp::NullishCoalescing
+            ) =>
+        {
+            visit_value_source_identifiers(&binary.left, visitor);
+            visit_value_source_identifiers(&binary.right, visitor);
+        }
         Expr::Cond(cond) => {
             visit_value_source_identifiers(&cond.cons, visitor);
             visit_value_source_identifiers(&cond.alt, visitor);
@@ -107,66 +254,262 @@ fn visit_value_source_identifiers(value: &Expr, visitor: &mut impl FnMut(&Ident)
                 visit_value_source_identifiers(value, visitor);
             }
         }
+        Expr::TsAs(ts_as) => visit_value_source_identifiers(&ts_as.expr, visitor),
+        Expr::TsConstAssertion(assertion) => {
+            visit_value_source_identifiers(&assertion.expr, visitor);
+        }
+        Expr::TsInstantiation(instantiation) => {
+            visit_value_source_identifiers(&instantiation.expr, visitor);
+        }
+        Expr::TsNonNull(non_null) => visit_value_source_identifiers(&non_null.expr, visitor),
+        Expr::TsSatisfies(satisfies) => {
+            visit_value_source_identifiers(&satisfies.expr, visitor);
+        }
+        Expr::TsTypeAssertion(assertion) => {
+            visit_value_source_identifiers(&assertion.expr, visitor);
+        }
         _ => {}
     }
 }
 
-impl Visit for ReturnRootBindingCollector {
+fn merge_reaching_definitions(
+    mut left: ReachingDefinitions,
+    right: ReachingDefinitions,
+) -> ReachingDefinitions {
+    for (binding, definitions) in right {
+        left.entry(binding).or_default().extend(definitions);
+    }
+    left
+}
+
+impl Visit for ReturnRootDefinitionCollector {
     noop_visit_type!();
 
     fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
 
-    fn visit_function(&mut self, _: &Function) {}
+    fn visit_break_stmt(&mut self, _: &BreakStmt) {
+        if !self.reachable {
+            return;
+        }
 
-    fn visit_assign_expr(&mut self, assign_expr: &AssignExpr) {
-        if assign_expr.op == AssignOp::Assign {
-            if let AssignTarget::Simple(SimpleAssignTarget::Ident(target)) = &assign_expr.left {
-                self.add_value_source(target, &assign_expr.right);
-            }
+        if let Some(environments) = self.break_environments.last_mut() {
+            environments.push(std::mem::take(&mut self.reaching));
+            self.reachable = false;
         }
     }
 
-    fn visit_jsx_element(&mut self, _: &JSXElement) {}
+    fn visit_function(&mut self, _: &Function) {}
 
-    fn visit_jsx_fragment(&mut self, _: &JSXFragment) {}
+    fn visit_for_in_stmt(&mut self, for_in_stmt: &ForInStmt) {
+        for_in_stmt.left.visit_with(self);
+        for_in_stmt.right.visit_with(self);
+        let input_reachable = self.reachable;
+
+        self.begin_loop();
+        for_in_stmt.body.visit_with(self);
+        let body = self.finish_branch();
+        self.finish_loop(body, true, input_reachable);
+    }
+
+    fn visit_for_of_stmt(&mut self, for_of_stmt: &ForOfStmt) {
+        for_of_stmt.left.visit_with(self);
+        for_of_stmt.right.visit_with(self);
+        let input_reachable = self.reachable;
+
+        self.begin_loop();
+        for_of_stmt.body.visit_with(self);
+        let body = self.finish_branch();
+        self.finish_loop(body, true, input_reachable);
+    }
+
+    fn visit_for_stmt(&mut self, for_stmt: &ForStmt) {
+        for_stmt.init.visit_with(self);
+        for_stmt.test.visit_with(self);
+        let input_reachable = self.reachable;
+
+        self.begin_loop();
+        for_stmt.update.visit_with(self);
+        for_stmt.body.visit_with(self);
+        let body = self.finish_branch();
+        self.finish_loop(body, true, input_reachable);
+    }
+
+    fn visit_assign_expr(&mut self, assign_expr: &AssignExpr) {
+        let AssignTarget::Simple(SimpleAssignTarget::Ident(target)) = &assign_expr.left else {
+            assign_expr.visit_children_with(self);
+            return;
+        };
+        if assign_expr.op != AssignOp::Assign {
+            assign_expr.visit_children_with(self);
+            return;
+        }
+
+        let definition = self.reserve_definition();
+        assign_expr.right.visit_with(self);
+        self.record_definition(definition, target, &assign_expr.right);
+    }
+
+    fn visit_if_stmt(&mut self, if_stmt: &IfStmt) {
+        if_stmt.test.visit_with(self);
+        let branch_reachable = self.reachable;
+
+        self.begin_branch();
+        if_stmt.cons.visit_with(self);
+        let consequent = self.finish_branch();
+
+        self.reachable = branch_reachable;
+        self.begin_branch();
+        if let Some(alternate) = &if_stmt.alt {
+            alternate.visit_with(self);
+        }
+        let alternate = self.finish_branch();
+
+        self.merge_branches(consequent, alternate);
+    }
 
     fn visit_return_stmt(&mut self, return_stmt: &ReturnStmt) {
         if let Some(value) = return_stmt.arg.as_deref() {
-            self.add_returned_value(value);
+            value.visit_with(self);
+            if self.reachable {
+                self.returned_definitions
+                    .extend(self.value_definitions(value));
+            }
         }
+        self.reachable = false;
+    }
+
+    fn visit_switch_stmt(&mut self, switch_stmt: &SwitchStmt) {
+        switch_stmt.discriminant.visit_with(self);
+        let switch_input = self.reaching.clone();
+        let switch_reachable = self.reachable;
+        let has_default = switch_stmt.cases.iter().any(|case| case.test.is_none());
+        let mut fallthrough = None;
+
+        self.break_environments.push(Vec::new());
+
+        for case in &switch_stmt.cases {
+            self.reaching = if let Some(fallthrough) = fallthrough.take() {
+                if switch_reachable {
+                    merge_reaching_definitions(switch_input.clone(), fallthrough)
+                } else {
+                    fallthrough
+                }
+            } else {
+                switch_input.clone()
+            };
+            self.reachable = switch_reachable || !self.reaching.is_empty();
+
+            if let Some(test) = &case.test {
+                test.visit_with(self);
+            }
+            for statement in &case.cons {
+                statement.visit_with(self);
+            }
+
+            if self.reachable {
+                fallthrough = Some(std::mem::take(&mut self.reaching));
+            }
+        }
+
+        let mut exits = self.break_environments.pop().unwrap_or_default();
+        if let Some(fallthrough) = fallthrough {
+            exits.push(fallthrough);
+        }
+        if switch_reachable && !has_default {
+            exits.push(switch_input);
+        }
+
+        let switch_reachable = !exits.is_empty();
+        let mut exits = exits.into_iter();
+        self.reaching = exits.next().unwrap_or_default();
+        for exit in exits {
+            self.reaching = merge_reaching_definitions(std::mem::take(&mut self.reaching), exit);
+        }
+        self.reachable = switch_reachable;
     }
 
     fn visit_var_declarator(&mut self, var_declarator: &VarDeclarator) {
-        if let (Pat::Ident(target), Some(value)) = (&var_declarator.name, &var_declarator.init) {
-            self.add_value_source(target, value);
-        }
+        let (Pat::Ident(target), Some(value)) = (&var_declarator.name, &var_declarator.init) else {
+            var_declarator.visit_children_with(self);
+            return;
+        };
+
+        let definition = self.reserve_definition();
+        value.visit_with(self);
+        self.record_definition(definition, target, value);
+    }
+
+    fn visit_while_stmt(&mut self, while_stmt: &WhileStmt) {
+        while_stmt.test.visit_with(self);
+        let input_reachable = self.reachable;
+
+        self.begin_loop();
+        while_stmt.body.visit_with(self);
+        let body = self.finish_branch();
+        self.finish_loop(body, true, input_reachable);
+    }
+
+    fn visit_do_while_stmt(&mut self, do_while_stmt: &DoWhileStmt) {
+        do_while_stmt.test.visit_with(self);
+        let input_reachable = self.reachable;
+
+        self.begin_loop();
+        do_while_stmt.body.visit_with(self);
+        let body = self.finish_branch();
+        self.finish_loop(body, false, input_reachable);
     }
 }
 
-fn returned_value_identifiers_from_block(block: &BlockStmt) -> FxHashSet<Id> {
-    let mut collector = ReturnRootBindingCollector::default();
+fn return_root_definitions_from_block(block: &BlockStmt) -> ReturnRootDefinitions {
+    let mut collector = ReturnRootDefinitionCollector::new();
     block.visit_with(&mut collector);
-    collector.return_root_bindings()
+    collector.finish()
 }
 
-fn returned_value_identifiers_from_function(function: &Function) -> FxHashSet<Id> {
+fn return_root_definitions_from_function(function: &Function) -> ReturnRootDefinitions {
     function
         .body
         .as_ref()
-        .map(returned_value_identifiers_from_block)
+        .map(return_root_definitions_from_block)
         .unwrap_or_default()
 }
 
-fn returned_value_identifiers_from_arrow(arrow_expr: &ArrowExpr) -> FxHashSet<Id> {
+fn return_root_definitions_from_arrow(arrow_expr: &ArrowExpr) -> ReturnRootDefinitions {
     match arrow_expr.body.as_ref() {
-        BlockStmtOrExpr::BlockStmt(block) => returned_value_identifiers_from_block(block),
-        BlockStmtOrExpr::Expr(expr) => match expr.as_ref() {
-            Expr::Ident(ident) => std::iter::once(ident.to_id()).collect(),
-            _ => FxHashSet::default(),
-        },
+        BlockStmtOrExpr::BlockStmt(block) => return_root_definitions_from_block(block),
+        BlockStmtOrExpr::Expr(expr) => {
+            let mut collector = ReturnRootDefinitionCollector::new();
+            expr.visit_with(&mut collector);
+            collector
+                .returned_definitions
+                .extend(collector.value_definitions(expr));
+            collector.finish()
+        }
         #[cfg(swc_ast_unknown)]
         _ => panic!("unknown block stmt or expr"),
     }
+}
+
+fn commonjs_require_source(expr: &Expr) -> Option<&str> {
+    let Expr::Call(call) = expr else {
+        return None;
+    };
+    let Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    if !matches!(callee.as_ref(), Expr::Ident(ident) if ident.sym.as_ref() == "require") {
+        return None;
+    }
+    let [argument] = call.args.as_slice() else {
+        return None;
+    };
+    if argument.spread.is_some() {
+        return None;
+    }
+    let Expr::Lit(Lit::Str(source)) = argument.expr.as_ref() else {
+        return None;
+    };
+    source.value.as_str()
 }
 
 pub struct ReactComponentAnnotateVisitor {
@@ -176,7 +519,7 @@ pub struct ReactComponentAnnotateVisitor {
     current_component_name: Option<Atom>,
     fragment_child_component_name: Option<Atom>,
     current_return_component_name: Option<Atom>,
-    return_root_bindings: FxHashSet<Id>,
+    return_root_definitions: ReturnRootDefinitions,
     react_compiler_enabled: bool,
     ignored_elements: &'static FxHashSet<&'static str>,
     ignored_components_set: FxHashSet<String>,
@@ -236,7 +579,7 @@ impl ReactComponentAnnotateVisitor {
             current_component_name: None,
             fragment_child_component_name: None,
             current_return_component_name: None,
-            return_root_bindings: FxHashSet::default(),
+            return_root_definitions: ReturnRootDefinitions::default(),
             react_compiler_enabled: false,
             styled_import: None,
             react_memo_identifiers: FxHashSet::default(),
@@ -400,25 +743,22 @@ impl ReactComponentAnnotateVisitor {
     fn is_global_fragment_identifier(&self, ident: &Ident) -> bool {
         let id = ident.to_id();
 
-        self.scoped_jsx_identifier_status(&id).is_none()
-            && (self.fragment_component_identifiers.contains(&id)
-                || ident.sym.as_ref() == "Fragment")
+        self.fragment_component_identifiers.contains(&id)
+            || (self.scoped_jsx_identifier_status(&id).is_none()
+                && ident.sym.as_ref() == "Fragment")
     }
 
     #[inline]
     fn is_global_react_namespace_identifier(&self, ident: &Ident) -> bool {
         let id = ident.to_id();
 
-        self.scoped_jsx_identifier_status(&id).is_none()
-            && (self.react_namespace_identifiers.contains(&id) || ident.sym.as_ref() == "React")
+        self.react_namespace_identifiers.contains(&id)
+            || (self.scoped_jsx_identifier_status(&id).is_none() && ident.sym.as_ref() == "React")
     }
 
     #[inline]
     fn is_global_react_memo_identifier(&self, ident: &Ident) -> bool {
-        let id = ident.to_id();
-
-        self.scoped_jsx_identifier_status(&id).is_none()
-            && self.react_memo_identifiers.contains(&id)
+        self.react_memo_identifiers.contains(&ident.to_id())
     }
 
     #[inline]
@@ -540,7 +880,70 @@ impl ReactComponentAnnotateVisitor {
 
     fn register_var_decl_bindings(&mut self, var_decl: &VarDecl) {
         for declarator in &var_decl.decls {
+            self.register_commonjs_import(declarator);
             self.register_var_declarator_binding_with_kind(declarator, var_decl.kind);
+        }
+    }
+
+    fn register_commonjs_import(&mut self, declarator: &VarDeclarator) {
+        let Some(source) = declarator.init.as_deref().and_then(commonjs_require_source) else {
+            return;
+        };
+
+        match source {
+            "react/compiler-runtime" => {
+                self.react_compiler_enabled = true;
+            }
+            "react" => self.register_commonjs_react_pattern(&declarator.name),
+            _ => {}
+        }
+    }
+
+    fn register_commonjs_react_pattern(&mut self, pattern: &Pat) {
+        match pattern {
+            Pat::Ident(ident) => {
+                self.react_namespace_identifiers.insert(ident.id.to_id());
+            }
+            Pat::Object(object) => {
+                for property in &object.props {
+                    match property {
+                        ObjectPatProp::KeyValue(key_value) => {
+                            let imported_name = match &key_value.key {
+                                PropName::Ident(ident) => Some(ident.sym.as_ref()),
+                                PropName::Str(str) => str.value.as_str(),
+                                _ => None,
+                            };
+                            let Pat::Ident(local) = key_value.value.as_ref() else {
+                                continue;
+                            };
+
+                            match imported_name {
+                                Some("Fragment") => {
+                                    self.fragment_component_identifiers.insert(local.id.to_id());
+                                }
+                                Some("memo") => {
+                                    self.react_memo_identifiers.insert(local.id.to_id());
+                                }
+                                _ => {}
+                            }
+                        }
+                        ObjectPatProp::Assign(assign) => match assign.key.id.sym.as_ref() {
+                            "Fragment" => {
+                                self.fragment_component_identifiers
+                                    .insert(assign.key.id.to_id());
+                            }
+                            "memo" => {
+                                self.react_memo_identifiers.insert(assign.key.id.to_id());
+                            }
+                            _ => {}
+                        },
+                        ObjectPatProp::Rest(_) => {}
+                        #[cfg(swc_ast_unknown)]
+                        _ => panic!("unknown object pattern prop"),
+                    }
+                }
+            }
+            _ => {}
         }
     }
 
@@ -570,10 +973,9 @@ impl ReactComponentAnnotateVisitor {
     }
 
     fn visit_var_declarator(&mut self, var_declarator: &mut VarDeclarator) {
-        let is_return_root_binding = matches!(
-            &var_declarator.name,
-            Pat::Ident(ident) if self.return_root_bindings.contains(&ident.id.to_id())
-        );
+        let is_return_root_definition = matches!(&var_declarator.name, Pat::Ident(_))
+            && var_declarator.init.is_some()
+            && self.return_root_definitions.next_is_root();
         let component_name = match &var_declarator.name {
             Pat::Ident(ident) => Some(ident.id.sym.clone()),
             _ => None,
@@ -581,7 +983,7 @@ impl ReactComponentAnnotateVisitor {
 
         var_declarator.name.visit_mut_with(self);
 
-        if is_return_root_binding {
+        if is_return_root_definition {
             if let Some(init) = &mut var_declarator.init {
                 self.visit_component_return_expr(init);
             }
@@ -881,10 +1283,10 @@ impl ReactComponentAnnotateVisitor {
         let prev_return_component = self.current_return_component_name.replace(component_name);
         let prev_component = self.current_component_name.take();
         let prev_fragment_child_component = self.fragment_child_component_name.take();
-        let prev_return_root_bindings = std::mem::replace(
-            &mut self.return_root_bindings,
+        let prev_return_root_definitions = std::mem::replace(
+            &mut self.return_root_definitions,
             self.react_compiler_enabled
-                .then(|| returned_value_identifiers_from_function(func))
+                .then(|| return_root_definitions_from_function(func))
                 .unwrap_or_default(),
         );
 
@@ -896,7 +1298,11 @@ impl ReactComponentAnnotateVisitor {
         self.current_return_component_name = prev_return_component;
         self.current_component_name = prev_component;
         self.fragment_child_component_name = prev_fragment_child_component;
-        self.return_root_bindings = prev_return_root_bindings;
+        debug_assert_eq!(
+            self.return_root_definitions.next_definition,
+            self.return_root_definitions.definition_count
+        );
+        self.return_root_definitions = prev_return_root_definitions;
     }
 
     fn visit_arrow_as_component(&mut self, arrow_expr: &mut ArrowExpr, component_name: Atom) {
@@ -907,10 +1313,10 @@ impl ReactComponentAnnotateVisitor {
         let prev_return_component = self.current_return_component_name.replace(component_name);
         let prev_component = self.current_component_name.take();
         let prev_fragment_child_component = self.fragment_child_component_name.take();
-        let prev_return_root_bindings = std::mem::replace(
-            &mut self.return_root_bindings,
+        let prev_return_root_definitions = std::mem::replace(
+            &mut self.return_root_definitions,
             self.react_compiler_enabled
-                .then(|| returned_value_identifiers_from_arrow(arrow_expr))
+                .then(|| return_root_definitions_from_arrow(arrow_expr))
                 .unwrap_or_default(),
         );
 
@@ -931,7 +1337,11 @@ impl ReactComponentAnnotateVisitor {
         self.current_return_component_name = prev_return_component;
         self.current_component_name = prev_component;
         self.fragment_child_component_name = prev_fragment_child_component;
-        self.return_root_bindings = prev_return_root_bindings;
+        debug_assert_eq!(
+            self.return_root_definitions.next_definition,
+            self.return_root_definitions.definition_count
+        );
+        self.return_root_definitions = prev_return_root_definitions;
     }
 
     fn visit_component_return_expr(&mut self, expr: &mut Expr) {
@@ -1031,7 +1441,7 @@ impl VisitMut for ReactComponentAnnotateVisitor {
         let prev_return_component = self.current_return_component_name.take();
         let prev_component = self.current_component_name.take();
         let prev_fragment_child_component = self.fragment_child_component_name.take();
-        let prev_return_root_bindings = std::mem::take(&mut self.return_root_bindings);
+        let prev_return_root_definitions = std::mem::take(&mut self.return_root_definitions);
 
         self.jsx_bindings
             .push_function_with(collect_function_param_scope(&function.params));
@@ -1041,7 +1451,7 @@ impl VisitMut for ReactComponentAnnotateVisitor {
         self.current_return_component_name = prev_return_component;
         self.current_component_name = prev_component;
         self.fragment_child_component_name = prev_fragment_child_component;
-        self.return_root_bindings = prev_return_root_bindings;
+        self.return_root_definitions = prev_return_root_definitions;
     }
 
     fn visit_mut_var_decl(&mut self, var_decl: &mut VarDecl) {
@@ -1115,7 +1525,7 @@ impl VisitMut for ReactComponentAnnotateVisitor {
         let prev_return_component = self.current_return_component_name.take();
         let prev_component = self.current_component_name.take();
         let prev_fragment_child_component = self.fragment_child_component_name.take();
-        let prev_return_root_bindings = std::mem::take(&mut self.return_root_bindings);
+        let prev_return_root_definitions = std::mem::take(&mut self.return_root_definitions);
 
         self.jsx_bindings
             .push_function_with(collect_pat_list_scope(&arrow_expr.params));
@@ -1125,16 +1535,16 @@ impl VisitMut for ReactComponentAnnotateVisitor {
         self.current_return_component_name = prev_return_component;
         self.current_component_name = prev_component;
         self.fragment_child_component_name = prev_fragment_child_component;
-        self.return_root_bindings = prev_return_root_bindings;
+        self.return_root_definitions = prev_return_root_definitions;
     }
 
     fn visit_mut_assign_expr(&mut self, assign_expr: &mut AssignExpr) {
         let is_return_root_assignment = assign_expr.op == AssignOp::Assign
             && matches!(
                 &assign_expr.left,
-                AssignTarget::Simple(SimpleAssignTarget::Ident(ident))
-                    if self.return_root_bindings.contains(&ident.id.to_id())
-            );
+                AssignTarget::Simple(SimpleAssignTarget::Ident(_))
+            )
+            && self.return_root_definitions.next_is_root();
 
         if is_return_root_assignment {
             self.visit_component_return_expr(&mut assign_expr.right);

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -11,7 +11,7 @@ const pluginPath = path.resolve(
 export function transform(
   source: string,
   pluginConfig: PluginConfig = {},
-  swcOptions: Pick<Options, "jsc"> = {}
+  swcOptions: Pick<Options, "isModule" | "jsc"> = {}
 ): string {
   const jsc: NonNullable<Options["jsc"]> = {
     parser: {syntax: "ecmascript", jsx: true},
@@ -22,10 +22,15 @@ export function transform(
     jsc.transform = swcOptions.jsc.transform;
   }
 
-  return transformSync(source, {
+  const options: Options = {
     filename: path.resolve("tests/e2e/Button.jsx"),
     jsc,
-  }).code;
+  };
+  if (swcOptions.isModule !== undefined) {
+    options.isModule = swcOptions.isModule;
+  }
+
+  return transformSync(source, options).code;
 }
 
 /** SWC options that enable the automatic runtime + React Compiler. */

--- a/tests/e2e/react-compiler.test.ts
+++ b/tests/e2e/react-compiler.test.ts
@@ -223,46 +223,12 @@ test("attributes React Compiler cache values used by a logical return", () => {
   assert.match(code, /"data-sentry-component": "App-Grid"/);
 });
 
-test("attributes React Compiler cache values selected by a switch", () => {
+test("attributes separately cached JSX children", () => {
   const code = transform(
     `
-      function App({kind}) {
-        let root;
-        switch (kind) {
-          case "grid":
-            root = <Grid />;
-            break;
-          default:
-            root = <Button />;
-        }
-        return root;
-      }
-
-      function Grid(props) {
-        return <div {...props} />;
-      }
-
-      function Button(props) {
-        return <button {...props} />;
-      }
-    `,
-    {...sentryConfig, "transparent-components": ["Button", "Grid"]},
-    reactCompiler
-  );
-
-  assert.match(code, /"data-sentry-component": "App-Grid"/);
-  assert.match(code, /"data-sentry-component": "App-Button"/);
-});
-
-test("attributes initial and reassigned React Compiler loop values", () => {
-  const code = transform(
-    `
-      function App({items}) {
-        let root = <Grid />;
-        for (const item of items) {
-          root = <Button key={item} />;
-        }
-        return root;
+      function App({label}) {
+        const button = <Button />;
+        return <Grid label={label}>{button}</Grid>;
       }
 
       function Grid(props) {

--- a/tests/e2e/react-compiler.test.ts
+++ b/tests/e2e/react-compiler.test.ts
@@ -76,6 +76,28 @@ test("attributes transparent callsites owned by memo components", () => {
   }
 });
 
+test("supports transparent memo owners in CommonJS scripts", () => {
+  const code = transform(
+    `
+      const React = require("react");
+
+      const MemoActions = React.memo(function MemoActions() {
+        return <Grid />;
+      });
+
+      function Grid(props) {
+        return <div {...props} />;
+      }
+
+      module.exports = MemoActions;
+    `,
+    {...sentryConfig, "transparent-components": ["Grid"]},
+    {...reactCompiler, isModule: false}
+  );
+
+  assert.match(code, /"data-sentry-component": "MemoActions-Grid"/);
+});
+
 test("does not treat non-return JSX as a React Compiler render root", () => {
   const code = transform(
     `
@@ -94,6 +116,33 @@ test("does not treat non-return JSX as a React Compiler render root", () => {
 
   assert.match(code, /register\([\s\S]*?_jsx\(Grid,/);
   assert.doesNotMatch(code, /"data-sentry-component": "App-Grid"/);
+});
+
+test("does not treat a later reassignment as a returned render root", () => {
+  const code = transform(
+    `
+      function App({notify}) {
+        let value = <Grid />;
+        const root = value;
+        value = <Button />;
+        notify(value);
+        return root;
+      }
+
+      function Grid(props) {
+        return <div {...props} />;
+      }
+
+      function Button(props) {
+        return <button {...props} />;
+      }
+    `,
+    {...sentryConfig, "transparent-components": ["Button", "Grid"]},
+    reactCompiler
+  );
+
+  assert.match(code, /"data-sentry-component": "App-Grid"/);
+  assert.doesNotMatch(code, /"data-sentry-component": "App-Button"/);
 });
 
 test("attributes React Compiler cache values forwarded through a returned local", () => {
@@ -135,6 +184,84 @@ test("attributes React Compiler cache values selected by a returned conditional"
         const first = <Grid />;
         const second = <Button />;
         root = ready ? first : second;
+        return root;
+      }
+
+      function Grid(props) {
+        return <div {...props} />;
+      }
+
+      function Button(props) {
+        return <button {...props} />;
+      }
+    `,
+    {...sentryConfig, "transparent-components": ["Button", "Grid"]},
+    reactCompiler
+  );
+
+  assert.match(code, /"data-sentry-component": "App-Grid"/);
+  assert.match(code, /"data-sentry-component": "App-Button"/);
+});
+
+test("attributes React Compiler cache values used by a logical return", () => {
+  const code = transform(
+    `
+      function App({ready}) {
+        const first = <Grid />;
+        const root = ready && first;
+        return root;
+      }
+
+      function Grid(props) {
+        return <div {...props} />;
+      }
+    `,
+    {...sentryConfig, "transparent-components": ["Grid"]},
+    reactCompiler
+  );
+
+  assert.match(code, /"data-sentry-component": "App-Grid"/);
+});
+
+test("attributes React Compiler cache values selected by a switch", () => {
+  const code = transform(
+    `
+      function App({kind}) {
+        let root;
+        switch (kind) {
+          case "grid":
+            root = <Grid />;
+            break;
+          default:
+            root = <Button />;
+        }
+        return root;
+      }
+
+      function Grid(props) {
+        return <div {...props} />;
+      }
+
+      function Button(props) {
+        return <button {...props} />;
+      }
+    `,
+    {...sentryConfig, "transparent-components": ["Button", "Grid"]},
+    reactCompiler
+  );
+
+  assert.match(code, /"data-sentry-component": "App-Grid"/);
+  assert.match(code, /"data-sentry-component": "App-Button"/);
+});
+
+test("attributes initial and reassigned React Compiler loop values", () => {
+  const code = transform(
+    `
+      function App({items}) {
+        let root = <Grid />;
+        for (const item of items) {
+          root = <Button key={item} />;
+        }
         return root;
       }
 

--- a/tests/e2e/react-compiler.test.ts
+++ b/tests/e2e/react-compiler.test.ts
@@ -30,7 +30,8 @@ test("passes owner metadata through transparent component callsites with React C
     reactCompiler
   );
 
-  assert.match(code, /_jsx\(Button, \{\s+"aria-label": "Show fingerprints",\s+"data-sentry-component": "MergedItem"/);
+  assert.match(code, /_jsx\(Grid, \{\s+"data-sentry-component": "MergedItem-Grid"/);
+  assert.match(code, /_jsx\(Button, \{\s+"aria-label": "Show fingerprints",\s+"data-sentry-component": "MergedItem-Button"/);
   assert.doesNotMatch(code, /"data-sentry-element": "Button"/);
   assert.match(code, /_jsx\("button", _object_spread\(\{\}, props\)\)/);
 });
@@ -68,7 +69,7 @@ test("annotates nested cached React Compiler return values", () => {
     reactCompiler
   );
 
-  assert.match(code, /_jsx\(Button, \{\s+"data-sentry-component": "ConditionalActions"/);
+  assert.match(code, /_jsx\(Button, \{\s+"data-sentry-component": "ConditionalActions-Button"/);
   assert.match(code, /_jsx\("div", \{\s+"data-sentry-component": "ConditionalActions"/);
   assert.doesNotMatch(code, /"data-sentry-element": "Button"/);
 });

--- a/tests/e2e/react-compiler.test.ts
+++ b/tests/e2e/react-compiler.test.ts
@@ -36,6 +36,124 @@ test("passes owner metadata through transparent component callsites with React C
   assert.match(code, /_jsx\("button", _object_spread\(\{\}, props\)\)/);
 });
 
+test("attributes transparent callsites owned by memo components", () => {
+  const source = `
+    import React, {memo} from "react";
+
+    const MemoActions = memo(function MemoActions() {
+      return <Button />;
+    });
+
+    const NamespaceMemoActions = React.memo(function NamespaceMemoActions() {
+      return <Button />;
+    });
+
+    function Button(props) {
+      return <button {...props} />;
+    }
+  `;
+
+  for (const [runtime, swcOptions] of [
+    ["classic", {}],
+    ["react compiler", reactCompiler],
+  ] as const) {
+    const code = transform(
+      source,
+      {...sentryConfig, "transparent-components": ["Button"]},
+      swcOptions
+    );
+
+    assert.match(
+      code,
+      /"data-sentry-component": "MemoActions-Button"/,
+      `${runtime} should keep the memo component as the transparent owner`
+    );
+    assert.match(
+      code,
+      /"data-sentry-component": "NamespaceMemoActions-Button"/,
+      `${runtime} should keep the React.memo component as the transparent owner`
+    );
+  }
+});
+
+test("does not treat non-return JSX as a React Compiler render root", () => {
+  const code = transform(
+    `
+      function App() {
+        register(<Grid />);
+        return <div />;
+      }
+
+      function Grid(props) {
+        return <div {...props} />;
+      }
+    `,
+    {...sentryConfig, "transparent-components": ["Grid"]},
+    reactCompiler
+  );
+
+  assert.match(code, /register\([\s\S]*?_jsx\(Grid,/);
+  assert.doesNotMatch(code, /"data-sentry-component": "App-Grid"/);
+});
+
+test("attributes React Compiler cache values forwarded through a returned local", () => {
+  const code = transform(
+    `
+      function App({ready}) {
+        let root;
+        if (ready) {
+          root = (
+            <Grid>
+              <Button />
+            </Grid>
+          );
+        }
+        return root;
+      }
+
+      function Grid(props) {
+        return <div {...props} />;
+      }
+
+      function Button(props) {
+        return <button {...props} />;
+      }
+    `,
+    {...sentryConfig, "transparent-components": ["Button", "Grid"]},
+    reactCompiler
+  );
+
+  assert.match(code, /"data-sentry-component": "App-Grid"/);
+  assert.match(code, /"data-sentry-component": "App-Button"/);
+});
+
+test("attributes React Compiler cache values selected by a returned conditional", () => {
+  const code = transform(
+    `
+      function App({ready}) {
+        let root;
+        const first = <Grid />;
+        const second = <Button />;
+        root = ready ? first : second;
+        return root;
+      }
+
+      function Grid(props) {
+        return <div {...props} />;
+      }
+
+      function Button(props) {
+        return <button {...props} />;
+      }
+    `,
+    {...sentryConfig, "transparent-components": ["Button", "Grid"]},
+    reactCompiler
+  );
+
+  assert.match(code, /"data-sentry-component": "App-Grid"/);
+  assert.match(code, /"data-sentry-component": "App-Button"/);
+});
+
 test("annotates cached React Compiler return values", () => {
   const code = transform(
     `

--- a/tests/e2e/swc-transform.test.ts
+++ b/tests/e2e/swc-transform.test.ts
@@ -64,7 +64,9 @@ test("passes owner metadata through transparent component callsites", () => {
     {...sentryConfig, "transparent-components": ["Button", "Flex", "Grid"]}
   );
 
-  assert.match(code, /React\.createElement\(Button, \{\s+"aria-label": "Show fingerprints",\s+"data-sentry-component": "MergedItem"/);
+  assert.match(code, /React\.createElement\(Grid, \{\s+"data-sentry-component": "MergedItem-Grid"/);
+  assert.match(code, /React\.createElement\(Flex, \{\s+"data-sentry-component": "MergedItem-Flex"/);
+  assert.match(code, /React\.createElement\(Button, \{\s+"aria-label": "Show fingerprints",\s+"data-sentry-component": "MergedItem-Button"/);
   assert.doesNotMatch(code, /"data-sentry-element": "Button"/);
   assert.match(code, /React\.createElement\("button", props\)/);
 });

--- a/tests/fixture/react_transparent_components/output.jsx
+++ b/tests/fixture/react_transparent_components/output.jsx
@@ -1,36 +1,36 @@
 import React, { memo } from 'react';
 import styled from '@emotion/styled';
 function ReplayDetails() {
-    return <Flex data-component="ReplayDetails" data-source-file="test.jsx"/>;
+    return <Flex data-component="ReplayDetails-Flex" data-source-file="test.jsx"/>;
 }
 function MetricsToolbar() {
-    return <Grid data-component="MetricsToolbar" data-source-file="test.jsx"/>;
+    return <Grid data-component="MetricsToolbar-Grid" data-source-file="test.jsx"/>;
 }
 function FirstLastSeenSection() {
-    return <Stack data-component="FirstLastSeenSection" data-source-file="test.jsx"/>;
+    return <Stack data-component="FirstLastSeenSection-Stack" data-source-file="test.jsx"/>;
 }
 function CheckoutSummary() {
-    return <Stack data-component="CheckoutSummary" data-source-file="test.jsx">
-      <Button data-component="CheckoutSummary" data-source-file="test.jsx"/>
+    return <Stack data-component="CheckoutSummary-Stack" data-source-file="test.jsx">
+      <Button data-component="CheckoutSummary-Button" data-source-file="test.jsx"/>
       <StyledFlex data-element="StyledFlex" data-source-file="test.jsx"/>
-      <Grid data-component="CheckoutSummary" data-source-file="test.jsx"/>
+      <Grid data-component="CheckoutSummary-Grid" data-source-file="test.jsx"/>
     </Stack>;
 }
 function LayoutStackUsage() {
-    return <LayoutStack data-component="LayoutStackUsage" data-source-file="test.jsx"/>;
+    return <LayoutStack data-component="LayoutStackUsage-LayoutStack" data-source-file="test.jsx"/>;
 }
 function TransparentButtonWithSpread(props) {
-    return <Button data-component="TransparentButtonWithSpread" data-source-file="test.jsx" {...props}/>;
+    return <Button data-component="TransparentButtonWithSpread-Button" data-source-file="test.jsx" {...props}/>;
 }
 function MergedItem() {
     return <MergedGroup data-element="MergedGroup" data-component="MergedItem" data-source-file="test.jsx">
-      <Grid data-component="MergedItem" data-source-file="test.jsx">
-        <Flex data-component="MergedItem" data-source-file="test.jsx">
-          <Text data-component="MergedItem" data-source-file="test.jsx">
-            <Link data-component="MergedItem" data-source-file="test.jsx">Latest event</Link>
+      <Grid data-component="MergedItem-Grid" data-source-file="test.jsx">
+        <Flex data-component="MergedItem-Flex" data-source-file="test.jsx">
+          <Text data-component="MergedItem-Text" data-source-file="test.jsx">
+            <Link data-component="MergedItem-Link" data-source-file="test.jsx">Latest event</Link>
           </Text>
         </Flex>
-        <Button aria-label="Show fingerprints" data-component="MergedItem" data-source-file="test.jsx"/>
+        <Button aria-label="Show fingerprints" data-component="MergedItem-Button" data-source-file="test.jsx"/>
       </Grid>
     </MergedGroup>;
 }


### PR DESCRIPTION
Transparent components used to collapse to the root owner, which loses which design-system component rendered the DOM.

before

```jsx
<Button data-sentry-component="MergedItem" />
```

after

```jsx
<Button data-sentry-component="MergedItem-Button" />
```

Nested transparent components keep the same root and do not accumulate wrapper names, so `Flex` and its nested `Button` become `MergedItem-Flex` and `MergedItem-Button`.

Also preserves these labels when React Compiler moves returned JSX through cache assignments and aliases, including memo components and conditional or logical returns.
